### PR TITLE
Use single argparser for all implementations

### DIFF
--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -1,0 +1,49 @@
+"""
+Command line interface implementation for pyclean.
+"""
+import argparse
+
+
+def parse_arguments():
+    """
+    Parse and handle CLI arguments
+    """
+    parser = argparse.ArgumentParser(
+        description='Remove byte-compiled files for a package')
+    parser.add_argument('-p', '--package', metavar='PACKAGE',
+                        action='append', default=[],
+                        help='Debian package to byte-compile '
+                             '(may be specified multiple times)')
+    parser.add_argument('directory', nargs='*',
+                        help='Directory tree (or file) to byte-compile')
+
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument('-v', '--verbose', action='store_true',
+                           help='Be more verbose')
+    verbosity.add_argument('-q', '--quiet', action='store_true',
+                           help='Be quiet')
+
+    args = parser.parse_args()
+
+    if not (args.package or args.directory):
+        parser.error('A directory (or files) or a list of packages '
+                     'must be specified.')
+    return args
+
+
+def pyclean():
+    from . import pyclean
+    args = parse_arguments()
+    pyclean.main(args)
+
+
+def py3clean():
+    from . import py3clean
+    args = parse_arguments()
+    py3clean.main(args)
+
+
+def pypyclean():
+    from . import pypyclean
+    args = parse_arguments()
+    pypyclean.main(args)

--- a/pyclean/pyclean.py
+++ b/pyclean/pyclean.py
@@ -1,31 +1,22 @@
-#! /usr/bin/python2
-# -*- coding: UTF-8 -*- vim: et ts=4 sw=4
-#
-# Copyright © 2010-2012 Piotr Ożarowski <piotr@debian.org>
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# coding=utf-8
+"""
+Python 2 pyclean implementation.
 
+TODO: move it to manpage
+Examples:
+    pyclean -p python-mako # all .py[co] files from the package
+    pyclean /usr/lib/python2.6/dist-packages # python2.6
+
+Original source at:
+https://salsa.debian.org/cpython-team/python-defaults/blob/master/pyclean
+
+Copyright © 2010-2012 Piotr Ożarowski <piotr@debian.org>
+"""
 import logging
-import optparse
 import sys
 from os import environ, remove
 from os.path import exists
+
 sys.path.insert(1, '/usr/share/python/')
 
 from debpython import files as dpf
@@ -35,12 +26,6 @@ from debpython.namespace import add_namespace_files
 logging.basicConfig(format='%(levelname).1s: %(module)s:%(lineno)d: '
                            '%(message)s')
 log = logging.getLogger(__name__)
-
-"""TODO: move it to manpage
-Examples:
-    pyclean -p python-mako # all .py[co] files from the package
-    pyclean /usr/lib/python2.6/dist-packages # python2.6
-"""
 
 
 def destroyer():  # ;-)
@@ -60,29 +45,18 @@ def destroyer():  # ;-)
                     log.debug('removing %s', filename)
                     remove(filename)
                     counter += 1
-                except (IOError, OSError), e:
+                except (IOError, OSError) as e:
                     log.error('cannot remove %s', filename)
                     log.debug(e)
     except GeneratorExit:
         log.info("removed files: %s", counter)
 
 
-def main():
-    usage = '%prog [-p PACKAGE] [DIR_OR_FILE]'
-    parser = optparse.OptionParser(usage, version='%prog 1.0')
-    parser.add_option('-v', '--verbose', action='store_true', dest='verbose',
-        help='turn verbose more one')
-    parser.add_option('-q', '--quiet', action='store_false', dest='verbose',
-        default=False, help='be quiet')
-    parser.add_option('-p', '--package',
-        help='specify Debian package name to clean')
-
-    options, args = parser.parse_args()
-
-    if options.verbose or environ.get('PYCLEAN_DEBUG') == '1':
+def main(args):
+    """Entry point for Python 2"""
+    if args.verbose or environ.get('PYCLEAN_DEBUG') == '1':
         log.setLevel(logging.DEBUG)
         log.debug('argv: %s', sys.argv)
-        log.debug('options: %s', options)
         log.debug('args: %s', args)
     else:
         log.setLevel(logging.WARNING)
@@ -90,28 +64,21 @@ def main():
     d = destroyer()
     d.next()  # initialize coroutine
 
-    if not options.package and not args:
-        parser.print_usage()
-        exit(1)
-
-    if options.package:
-        log.info('cleaning package %s', options.package)
-        pfiles = dpf.from_package(options.package, extensions=('.py', '.so'))
-        pfiles = add_namespace_files(pfiles, options.package, action=False)
+    if args.package:
+        log.info('cleaning package %s', args.package)
+        pfiles = dpf.from_package(args.package, extensions=('.py', '.so'))
+        pfiles = add_namespace_files(pfiles, args.package, action=False)
         pfiles = set(dpf.filter_out_ext(pfiles, ('.so',)))
 
-    if args:
-        log.info('cleaning directories: %s', args)
-        files = dpf.from_directory(args, extensions=('.py', '.so'))
+    if args.directory:
+        log.info('cleaning directories: %s', args.directory)
+        files = dpf.from_directory(args.directory, extensions=('.py', '.so'))
         files = add_namespace_files(files, action=False)
         files = set(dpf.filter_out_ext(files, ('.so',)))
-        if options.package:
+        if args.package:
             files = files & pfiles
     else:
         files = pfiles
 
     for filename in files:
         d.send(filename)
-
-if __name__ == '__main__':
-    main()

--- a/pyclean/pypyclean.py
+++ b/pyclean/pypyclean.py
@@ -8,16 +8,15 @@ https://salsa.debian.org/debian/pypy/blob/debian/debian/scripts/pypyclean
 Copyright © 2013-2019 Stefano Rivera <stefanor@debian.org>
 """
 import collections
+import errno
 import itertools
 import os
 import shutil
 import subprocess
-import sys
 
 
 def abort(message):
-    print >> sys.stderr, message
-    sys.exit(1)
+    raise SystemExit(message)
 
 
 def package_modules(package):
@@ -65,10 +64,10 @@ def cleanup_namespaces(package, verbose):
                             namespace.replace('.', '/'),
                             '__init__.py')
         if not os.path.exists(init):
-            print 'Missing namespace init: %s' % init
+            print('Missing namespace init: %s' % init)
             continue
         if os.path.getsize(init) != 0:
-            print 'Non-empty init, ignoring: %s' % init
+            print('Non-empty init, ignoring: %s' % init)
             continue
         inits_to_remove.append(init)
 
@@ -130,14 +129,14 @@ def clean_modules(modules, verbose):
         for fn in os.listdir(pycache):
             if fn.endswith('.pyc') and fn.rsplit('.', 2)[0] in basenames:
                 if verbose:
-                    print 'Removing %s' % os.path.join(pycache, fn)
+                    print('Removing %s' % os.path.join(pycache, fn))
                 os.unlink(os.path.join(pycache, fn))
             else:
                 empty = False
 
         if empty:
             if verbose:
-                print 'Pruning %s' % pycache
+                print('Pruning %s' % pycache)
             os.rmdir(pycache)
 
 
@@ -148,7 +147,7 @@ def clean_directories(directories, verbose):
             for dir_ in dirnames:
                 if dir_ == '__pycache__':
                     if verbose:
-                        print 'Removing %s' % os.path.join(dirpath, dir_)
+                        print('Removing %s' % os.path.join(dirpath, dir_))
                     shutil.rmtree(os.path.join(dirpath, dir_))
 
 

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,9 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'pyclean = pyclean.pyclean:main',
-            'py3clean = pyclean.py3clean:main',
-            'pypyclean = pyclean.pypyclean:main',
+            'pyclean = pyclean.cli:pyclean',
+            'py3clean = pyclean.cli:py3clean',
+            'pypyclean = pyclean.cli:pypyclean',
         ],
     },
 )


### PR DESCRIPTION
* Phase out deprecated optparse in favor of argparse (py2, py3)
* Add cli module to handle command line input uniformly
* Use logging instead of print in PyPy code

@stefanor FYI