### PR TITLE
Refactor directory tests, fix missing argv[0]

### DIFF
--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -1,10 +1,13 @@
 """
 Tests for the cleaning logic on folders
 """
-import os
 import platform
 import pytest
 import sys
+
+import pyclean.cli
+
+from helpers import ArgvContext
 
 
 @pytest.mark.skipif(sys.version_info >= (3,), reason="requires Python 2")
@@ -12,8 +15,8 @@ def test_directory_py2():
     """
     Does traversing directories for cleaning work for Python 2?
     """
-    exit_status = os.system('pyclean foo')
-    assert exit_status == 0
+    with ArgvContext('pyclean', 'foo'):
+        pyclean.cli.pyclean()
 
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="requires Python 3")
@@ -21,8 +24,8 @@ def test_directory_py3():
     """
     Does traversing directories for cleaning work for Python 3?
     """
-    exit_status = os.system('py3clean foo')
-    assert exit_status == 0
+    with ArgvContext('py3clean', 'foo'):
+        pyclean.cli.py3clean()
 
 
 @pytest.mark.skipif(platform.python_implementation() != 'PyPy'
@@ -32,8 +35,8 @@ def test_directory_pypy():
     """
     Does traversing directories for cleaning work for PyPy?
     """
-    exit_status = os.system('pypyclean foo')
-    assert exit_status == 0
+    with ArgvContext('pypyclean', 'foo'):
+        pyclean.cli.pypyclean()
 
 
 @pytest.mark.skipif(platform.python_implementation() != 'PyPy'
@@ -43,5 +46,5 @@ def test_directory_pypy3():
     """
     Does traversing directories for cleaning work for PyPy3?
     """
-    exit_status = os.system('pypyclean foo')
-    assert exit_status == 0
+    with ArgvContext('pypyclean', 'foo'):
+        pyclean.cli.pypyclean()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -5,6 +5,11 @@ import platform
 import pytest
 import sys
 
+try:
+    from unittest.mock import patch
+except ImportError:  # Python 2.7, PyPy2
+    from mock import patch
+
 import pyclean.cli
 
 from helpers import ArgvContext
@@ -15,7 +20,7 @@ def test_package_py2():
     """
     Does collecting/traversing packages for cleaning work for Python 2?
     """
-    with ArgvContext('-p', 'python-apt'):
+    with ArgvContext('pyclean', '-p', 'python-apt'):
         pyclean.cli.pyclean()
 
 
@@ -24,27 +29,33 @@ def test_package_py3():
     """
     Does collecting/traversing packages for cleaning work for Python 3?
     """
-    with ArgvContext('-p', 'python-apt'):
+    with ArgvContext('py3clean', '-p', 'python-apt'):
         pyclean.cli.py3clean()
 
 
 @pytest.mark.skipif(platform.python_implementation() != 'PyPy'
                     or sys.version_info >= (3,),
                     reason="requires PyPy2")
-def test_package_pypy():
+@patch('pyclean.pypyclean.installed_namespaces', return_value={})
+def test_package_pypy(mock_namespaces):
     """
     Does collecting/traversing packages for cleaning work for PyPy?
     """
-    with ArgvContext('-p', 'python-apt'):
+    with ArgvContext('pypyclean', '-p', 'python-apt'):
         pyclean.cli.pypyclean()
+
+    assert mock_namespaces.called
 
 
 @pytest.mark.skipif(platform.python_implementation() != 'PyPy'
                     or sys.version_info < (3,),
                     reason="requires PyPy3")
-def test_package_pypy3():
+@patch('pyclean.pypyclean.installed_namespaces', return_value={})
+def test_package_pypy3(mock_namespaces):
     """
     Does collecting/traversing packages for cleaning work for PyPy3?
     """
-    with ArgvContext('-p', 'python-apt'):
+    with ArgvContext('pypyclean', '-p', 'python-apt'):
         pyclean.cli.pypyclean()
+
+    assert mock_namespaces.called

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -20,7 +20,7 @@ def test_filterversion_py2():
     """
     Does filtering by Python version work when run with Python 2?
     """
-    with ArgvContext('-V', '2.7', '-p', 'python-apt'):
+    with ArgvContext('pyclean', '-V', '2.7', '-p', 'python-apt'):
         pyclean.cli.pyclean()
 
 
@@ -29,7 +29,7 @@ def test_filterversion_py3():
     """
     Does filtering by Python version work when run with Python 3?
     """
-    with ArgvContext('-V', '3.5', '-p', 'python-apt'):
+    with ArgvContext('py3clean', '-V', '3.5', '-p', 'python-apt'):
         pyclean.cli.py3clean()
 
 
@@ -41,7 +41,7 @@ def test_filterversion_pypy(mock_namespaces):
     """
     Does filtering by Python version work when run with PyPy?
     """
-    with ArgvContext('-V', '2.7', '-p', 'python-apt'):
+    with ArgvContext('pypyclean', '-V', '2.7', '-p', 'python-apt'):
         pyclean.cli.pypyclean()
 
     assert mock_namespaces.called
@@ -55,7 +55,7 @@ def test_filterversion_pypy3(mock_namespaces):
     """
     Does filtering by Python version work when run with PyPy3?
     """
-    with ArgvContext('-V', '3.5', '-p', 'python-apt'):
+    with ArgvContext('pypyclean', '-V', '3.5', '-p', 'python-apt'):
         pyclean.cli.pypyclean()
 
     assert mock_namespaces.called


### PR DESCRIPTION
Mocking the CLI argument vector was missing out the first argument (i.e. the script name).

This PR fixes that flaw and it refactors the tests for the directory-based invocation, also using mocked args and direct calling of the code under test.