### PR TITLE
Autodetect active Python version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,8 +90,32 @@ Installation
 
     $ pip install pyclean
 
-This installs 3 CLI commands, ``pyclean``, ``py3clean``, ``pypyclean``,
-which are meant to be run for Python 2, Python 3 and PyPy 2.7.
+Usage
+=====
+
+.. code:: console
+
+    $ pyclean --help
+
+If you want to explicitly operate the version-specific implementation:
+
+.. code:: console
+
+    $ py2clean --help
+    $ py3clean --help
+    $ pypyclean --help
+
+Clean up all bytecode in the current directory tree, and explain verbosely:
+
+.. code:: console
+
+    $ pyclean -v .
+
+Clean up all bytecode for a Debian package: (may require root permissions)
+
+.. code:: console
+
+    $ pyclean -p python3-keyring
 
 Use pyclean with Tox
 --------------------

--- a/pyclean/__init__.py
+++ b/pyclean/__init__.py
@@ -3,6 +3,6 @@ Pure Python cross-platform pyclean. Clean up your Python bytecode.
 """
 __author__ = 'Peter Bittner'
 __email__ = 'django@bittner.it'
-__url__ = 'https://github.com/bittner/pyclean'
-__version__ = '2.0.0dev0'
 __license__ = 'GPLv3'
+__url__ = 'https://github.com/bittner/pyclean'
+__version__ = '2.0.0dev1'

--- a/pyclean/__main__.py
+++ b/pyclean/__main__.py
@@ -1,0 +1,6 @@
+"""
+Main entry point for running pyclean as a module.
+"""
+from . import cli
+
+cli.main()

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -37,10 +37,31 @@ def parse_arguments():
     return args
 
 
-def main():
+def main(override=None):
     """
     Entry point for all scripts
     """
     args = parse_arguments()
-    impl = compat.get_implementation()
+    impl = compat.get_implementation(override=override)
     impl.main(args)
+
+
+def py2clean():
+    """
+    Forces the use of the implementation for Python 2
+    """
+    main('CPython2')
+
+
+def py3clean():
+    """
+    Forces the use of the implementation for Python 3
+    """
+    main('CPython3')
+
+
+def pypyclean():
+    """
+    Forces the use of the implementation for PyPy (2+3)
+    """
+    main('PyPy2')

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -44,7 +44,3 @@ def main():
     args = parse_arguments()
     impl = compat.get_implementation()
     impl.main(args)
-
-
-# aliases (backward-compatibility)
-pyclean = py3clean = pypyclean = main

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -3,7 +3,7 @@ Command line interface implementation for pyclean.
 """
 import argparse
 
-from . import __version__
+from . import __version__, compat
 
 
 def parse_arguments():
@@ -37,19 +37,14 @@ def parse_arguments():
     return args
 
 
-def pyclean():
-    from . import pyclean
+def main():
+    """
+    Entry point for all scripts
+    """
     args = parse_arguments()
-    pyclean.main(args)
+    impl = compat.get_implementation()
+    impl.main(args)
 
 
-def py3clean():
-    from . import py3clean
-    args = parse_arguments()
-    py3clean.main(args)
-
-
-def pypyclean():
-    from . import pypyclean
-    args = parse_arguments()
-    pypyclean.main(args)
+# aliases (backward-compatibility)
+pyclean = py3clean = pypyclean = main

--- a/pyclean/compat.py
+++ b/pyclean/compat.py
@@ -1,0 +1,27 @@
+"""
+Cross-Python version compatibility.
+"""
+import importlib
+import platform
+import sys
+
+
+def get_implementation():
+    """
+    Return a reference to the function that implements
+    pyclean for the active Python version.
+    """
+    implementation = dict(
+        CPython2='pyclean.pyclean',
+        CPython3='pyclean.py3clean',
+        PyPy2='pyclean.pypyclean',
+        PyPy3='pyclean.pypyclean',
+    )
+
+    python_version = '%s%s' % (
+        platform.python_implementation(),
+        sys.version[0],
+    )
+
+    module = implementation[python_version]
+    return importlib.import_module(module)

--- a/pyclean/compat.py
+++ b/pyclean/compat.py
@@ -7,10 +7,10 @@ import sys
 from importlib import import_module
 
 
-def get_implementation():
+def get_implementation(override=None):
     """
-    Return a reference to the function that implements
-    pyclean for the active Python version.
+    Detect the active Python version and return a reference to the
+    module serving the version-specific pyclean implementation.
     """
     implementation = dict(
         CPython2='pyclean.pyclean',
@@ -19,10 +19,10 @@ def get_implementation():
         PyPy3='pyclean.pypyclean',
     )
 
-    python_version = '%s%s' % (
+    detected_version = '%s%s' % (
         platform.python_implementation(),
         sys.version[0],
     )
 
-    module_name = implementation[python_version]
+    module_name = implementation[override if override else detected_version]
     return import_module(module_name)

--- a/pyclean/compat.py
+++ b/pyclean/compat.py
@@ -1,9 +1,10 @@
 """
 Cross-Python version compatibility.
 """
-import importlib
 import platform
 import sys
+
+from importlib import import_module
 
 
 def get_implementation():
@@ -23,5 +24,5 @@ def get_implementation():
         sys.version[0],
     )
 
-    module = implementation[python_version]
-    return importlib.import_module(module)
+    module_name = implementation[python_version]
+    return import_module(module_name)

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ setup(
     entry_points={
         'console_scripts': [
             'pyclean = pyclean.cli:main',
+            'py2clean = pyclean.cli:py2clean',
+            'py3clean = pyclean.cli:py3clean',
+            'pypyclean = pyclean.cli:pypyclean',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'pyclean = pyclean.cli:pyclean',
-            'py3clean = pyclean.cli:py3clean',
-            'pypyclean = pyclean.cli:pypyclean',
+            'pyclean = pyclean.cli:main',
         ],
     },
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,9 +2,6 @@
 Tests for the pyclean CLI
 """
 import os
-import platform
-import pytest
-import sys
 
 try:
     from unittest.mock import patch
@@ -16,47 +13,11 @@ import pyclean.cli
 from helpers import ArgvContext
 
 
-@pytest.mark.skipif(platform.python_implementation() != 'CPython'
-                    or sys.version_info >= (3,),
-                    reason="requires CPython 2")
-def test_entrypoint_py2():
+def test_entrypoint():
     """
     Is entrypoint script installed for Python 2? (setup.py)
     """
     exit_status = os.system('pyclean --help')
-    assert exit_status == 0
-
-
-@pytest.mark.skipif(platform.python_implementation() != 'CPython'
-                    or sys.version_info < (3,),
-                    reason="requires CPython 3")
-def test_entrypoint_py3():
-    """
-    Is entrypoint script installed for Python 3? (setup.py)
-    """
-    exit_status = os.system('py3clean --help')
-    assert exit_status == 0
-
-
-@pytest.mark.skipif(platform.python_implementation() != 'PyPy'
-                    or sys.version_info >= (3,),
-                    reason="requires PyPy2")
-def test_entrypoint_pypy():
-    """
-    Is entrypoint script installed for PyPy? (setup.py)
-    """
-    exit_status = os.system('pypyclean --help')
-    assert exit_status == 0
-
-
-@pytest.mark.skipif(platform.python_implementation() != 'PyPy'
-                    or sys.version_info < (3,),
-                    reason="requires PyPy3")
-def test_entrypoint_pypy3():
-    """
-    Is entrypoint script installed for PyPy3? (setup.py)
-    """
-    exit_status = os.system('pypyclean --help')
     assert exit_status == 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,10 +15,70 @@ from helpers import ArgvContext
 
 def test_entrypoint():
     """
-    Is entrypoint script installed for Python 2? (setup.py)
+    Is entrypoint script installed? (setup.py)
     """
     exit_status = os.system('pyclean --help')
     assert exit_status == 0
+
+
+def test_entrypoint_py2_installed():
+    """
+    Is entrypoint script installed for Python 2? (setup.py)
+    """
+    exit_status = os.system('py2clean --help')
+    assert exit_status == 0
+
+
+@patch('pyclean.compat.import_module')
+def test_entrypoint_py2_working(mock_import_module):
+    """
+    Is entrypoint overriding with Python 2 implementation?
+    """
+    with ArgvContext('py2clean', 'foo'):
+        pyclean.cli.py2clean()
+
+    args, _ = mock_import_module.call_args
+    assert args == ('pyclean.pyclean',)
+
+
+def test_entrypoint_py3_installed():
+    """
+    Is entrypoint script installed for Python 3? (setup.py)
+    """
+    exit_status = os.system('py3clean --help')
+    assert exit_status == 0
+
+
+@patch('pyclean.compat.import_module')
+def test_entrypoint_py3_working(mock_import_module):
+    """
+    Is entrypoint overriding with Python 3 implementation?
+    """
+    with ArgvContext('py3clean', 'foo'):
+        pyclean.cli.py3clean()
+
+    args, _ = mock_import_module.call_args
+    assert args == ('pyclean.py3clean',)
+
+
+def test_entrypoint_pypy_installed():
+    """
+    Is entrypoint script installed for PyPy 2/3? (setup.py)
+    """
+    exit_status = os.system('pypyclean --help')
+    assert exit_status == 0
+
+
+@patch('pyclean.compat.import_module')
+def test_entrypoint_pypy_working(mock_import_module):
+    """
+    Is entrypoint overriding with PyPy implementation?
+    """
+    with ArgvContext('pypyclean', 'foo'):
+        pyclean.cli.pypyclean()
+
+    args, _ = mock_import_module.call_args
+    assert args == ('pyclean.pypyclean',)
 
 
 @patch('pyclean.compat.get_implementation')

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -16,7 +16,7 @@ from pyclean import compat
 @pytest.mark.skipif(platform.python_implementation() != 'CPython'
                     or sys.version_info >= (3,),
                     reason="requires CPython 2")
-def test_get_implementation_py2():
+def test_detect_py2():
     """
     Is pyclean implementation returned for Python 2?
     """
@@ -27,7 +27,7 @@ def test_get_implementation_py2():
 @pytest.mark.skipif(platform.python_implementation() != 'CPython'
                     or sys.version_info < (3,),
                     reason="requires CPython 3")
-def test_get_implementation_py3():
+def test_detect_py3():
     """
     Is py3clean implementation for Python 3?
     """
@@ -37,7 +37,7 @@ def test_get_implementation_py3():
 
 @pytest.mark.skipif(platform.python_implementation() != 'PyPy',
                     reason="requires PyPy")
-def test_get_implementation_pypy():
+def test_detect_pypy():
     """
     Is pypyclean implementation for PyPy?
     """

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,45 @@
+"""
+Tests for the cross-Python version compatibility module
+"""
+import platform
+import pytest
+import sys
+
+try:
+    from unittest.mock import patch
+except ImportError:  # Python 2.7, PyPy2
+    from mock import patch
+
+from pyclean import compat
+
+
+@pytest.mark.skipif(platform.python_implementation() != 'CPython'
+                    or sys.version_info >= (3,),
+                    reason="requires CPython 2")
+def test_get_implementation_py2():
+    """
+    Is pyclean implementation returned for Python 2?
+    """
+    from pyclean import pyclean
+    assert compat.get_implementation() is pyclean
+
+
+@pytest.mark.skipif(platform.python_implementation() != 'CPython'
+                    or sys.version_info < (3,),
+                    reason="requires CPython 3")
+def test_get_implementation_py3():
+    """
+    Is py3clean implementation for Python 3?
+    """
+    from pyclean import py3clean
+    assert compat.get_implementation() is py3clean
+
+
+@pytest.mark.skipif(platform.python_implementation() != 'PyPy',
+                    reason="requires PyPy")
+def test_get_implementation_pypy():
+    """
+    Is pypyclean implementation for PyPy?
+    """
+    from pyclean import pypyclean
+    assert compat.get_implementation() is pypyclean

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -5,11 +5,6 @@ import platform
 import pytest
 import sys
 
-try:
-    from unittest.mock import patch
-except ImportError:  # Python 2.7, PyPy2
-    from mock import patch
-
 from pyclean import compat
 
 

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -1,50 +1,14 @@
 """
 Tests for the cleaning logic on folders
 """
-import platform
-import pytest
-import sys
-
 import pyclean.cli
 
 from helpers import ArgvContext
 
 
-@pytest.mark.skipif(sys.version_info >= (3,), reason="requires Python 2")
-def test_directory_py2():
+def test_clean_directory():
     """
     Does traversing directories for cleaning work for Python 2?
     """
     with ArgvContext('pyclean', 'foo'):
-        pyclean.cli.pyclean()
-
-
-@pytest.mark.skipif(sys.version_info < (3,), reason="requires Python 3")
-def test_directory_py3():
-    """
-    Does traversing directories for cleaning work for Python 3?
-    """
-    with ArgvContext('py3clean', 'foo'):
-        pyclean.cli.py3clean()
-
-
-@pytest.mark.skipif(platform.python_implementation() != 'PyPy'
-                    or sys.version_info >= (3,),
-                    reason="requires PyPy2")
-def test_directory_pypy():
-    """
-    Does traversing directories for cleaning work for PyPy?
-    """
-    with ArgvContext('pypyclean', 'foo'):
-        pyclean.cli.pypyclean()
-
-
-@pytest.mark.skipif(platform.python_implementation() != 'PyPy'
-                    or sys.version_info < (3,),
-                    reason="requires PyPy3")
-def test_directory_pypy3():
-    """
-    Does traversing directories for cleaning work for PyPy3?
-    """
-    with ArgvContext('pypyclean', 'foo'):
-        pyclean.cli.pypyclean()
+        pyclean.cli.main()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -16,7 +16,7 @@ from helpers import ArgvContext
 
 @pytest.mark.skipif(platform.python_implementation() != 'CPython',
                     reason="requires CPython")
-def test_package_py2():
+def test_clean_package():
     """
     Does collecting/traversing packages for cleaning work for Python 2+3?
     """
@@ -27,11 +27,11 @@ def test_package_py2():
 @pytest.mark.skipif(platform.python_implementation() != 'PyPy',
                     reason="requires PyPy")
 @patch('pyclean.pypyclean.installed_namespaces', return_value={})
-def test_package_pypy(mock_namespaces):
+def test_clean_package_pypy(mock_namespaces):
     """
     Does collecting/traversing packages for cleaning work for PyPy?
     """
     with ArgvContext('pypyclean', '-p', 'python-apt'):
-        pyclean.cli.pypyclean()
+        pyclean.cli.main()
 
     assert mock_namespaces.called

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -3,7 +3,6 @@ Tests for the cleaning logic on Python packages
 """
 import platform
 import pytest
-import sys
 
 try:
     from unittest.mock import patch
@@ -15,45 +14,22 @@ import pyclean.cli
 from helpers import ArgvContext
 
 
-@pytest.mark.skipif(sys.version_info >= (3,), reason="requires Python 2")
+@pytest.mark.skipif(platform.python_implementation() != 'CPython',
+                    reason="requires CPython")
 def test_package_py2():
     """
-    Does collecting/traversing packages for cleaning work for Python 2?
+    Does collecting/traversing packages for cleaning work for Python 2+3?
     """
     with ArgvContext('pyclean', '-p', 'python-apt'):
-        pyclean.cli.pyclean()
+        pyclean.cli.main()
 
 
-@pytest.mark.skipif(sys.version_info < (3,), reason="requires Python 3")
-def test_package_py3():
-    """
-    Does collecting/traversing packages for cleaning work for Python 3?
-    """
-    with ArgvContext('py3clean', '-p', 'python-apt'):
-        pyclean.cli.py3clean()
-
-
-@pytest.mark.skipif(platform.python_implementation() != 'PyPy'
-                    or sys.version_info >= (3,),
-                    reason="requires PyPy2")
+@pytest.mark.skipif(platform.python_implementation() != 'PyPy',
+                    reason="requires PyPy")
 @patch('pyclean.pypyclean.installed_namespaces', return_value={})
 def test_package_pypy(mock_namespaces):
     """
     Does collecting/traversing packages for cleaning work for PyPy?
-    """
-    with ArgvContext('pypyclean', '-p', 'python-apt'):
-        pyclean.cli.pypyclean()
-
-    assert mock_namespaces.called
-
-
-@pytest.mark.skipif(platform.python_implementation() != 'PyPy'
-                    or sys.version_info < (3,),
-                    reason="requires PyPy3")
-@patch('pyclean.pypyclean.installed_namespaces', return_value={})
-def test_package_pypy3(mock_namespaces):
-    """
-    Does collecting/traversing packages for cleaning work for PyPy3?
     """
     with ArgvContext('pypyclean', '-p', 'python-apt'):
         pyclean.cli.pypyclean()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -3,7 +3,6 @@ Tests for filtering by Python version
 """
 import platform
 import pytest
-import sys
 
 try:
     from unittest.mock import patch

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -15,47 +15,24 @@ import pyclean.cli
 from helpers import ArgvContext
 
 
-@pytest.mark.skipif(sys.version_info >= (3,), reason="requires Python 2")
-def test_filterversion_py2():
-    """
-    Does filtering by Python version work when run with Python 2?
-    """
-    with ArgvContext('pyclean', '-V', '2.7', '-p', 'python-apt'):
-        pyclean.cli.pyclean()
-
-
-@pytest.mark.skipif(sys.version_info < (3,), reason="requires Python 3")
-def test_filterversion_py3():
+@pytest.mark.skipif(platform.python_implementation() != 'CPython',
+                    reason="requires CPython")
+def test_filterversion_py():
     """
     Does filtering by Python version work when run with Python 3?
     """
-    with ArgvContext('py3clean', '-V', '3.5', '-p', 'python-apt'):
-        pyclean.cli.py3clean()
+    with ArgvContext('pyclean', '-V', '3.5', '-p', 'python-apt'):
+        pyclean.cli.main()
 
 
-@pytest.mark.skipif(platform.python_implementation() != 'PyPy'
-                    or sys.version_info >= (3,),
-                    reason="requires PyPy2")
+@pytest.mark.skipif(platform.python_implementation() != 'PyPy',
+                    reason="requires PyPy")
 @patch('pyclean.pypyclean.installed_namespaces', return_value={})
 def test_filterversion_pypy(mock_namespaces):
     """
     Does filtering by Python version work when run with PyPy?
     """
     with ArgvContext('pypyclean', '-V', '2.7', '-p', 'python-apt'):
-        pyclean.cli.pypyclean()
-
-    assert mock_namespaces.called
-
-
-@pytest.mark.skipif(platform.python_implementation() != 'PyPy'
-                    or sys.version_info < (3,),
-                    reason="requires PyPy3")
-@patch('pyclean.pypyclean.installed_namespaces', return_value={})
-def test_filterversion_pypy3(mock_namespaces):
-    """
-    Does filtering by Python version work when run with PyPy3?
-    """
-    with ArgvContext('pypyclean', '-V', '3.5', '-p', 'python-apt'):
-        pyclean.cli.pypyclean()
+        pyclean.cli.main()
 
     assert mock_namespaces.called

--- a/tox.ini
+++ b/tox.ini
@@ -20,13 +20,13 @@ commands = pytest
 
 [testenv:bandit]
 description = PyCQA security linter
-deps = bandit
-commands = bandit -r .
+deps = bandit<1.6.0
+commands = bandit -r . --ini tox.ini
 
 [testenv:clean]
 description = Clean up bytecode
 deps = pyclean
-commands = py3clean -v {toxinidir}
+commands = pyclean -v {toxinidir}
 
 [testenv:flake8]
 description = Static code analysis and code style


### PR DESCRIPTION
- Add compat module and autodect active Python version
- Install `py2clean` entry point for version-explicit CLI use
- Add usage section to README

Fixes issue #7.