### PR TITLE
Add workflow for checks with GitHub Actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,24 @@
+name: Checks
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [flake8, pylint, readme]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install prerequisites
+      run: python -m pip install --upgrade setuptools pip wheel tox
+    - name: Run ${{ matrix.env }}
+      run: tox -e ${{ matrix.env }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,16 +14,12 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
-
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade setuptools pip wheel
-        python -m pip install tox-gh-actions
-    - name: Test with tox
+    - name: Install prerequisites
+      run: python -m pip install --upgrade setuptools pip wheel tox-gh-actions
+    - name: Run tests
       run: tox

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 pyclean |latest-version|
 ========================
 
-|travis-build| |appveyor-build| |health| |python-support| |license|
+|checks-status| |tests-status| |qa| |health| |python-support| |license|
 
 Worried about ``.pyc`` files and ``__pycache__`` directories? Fear not!
 Pyclean is here to help. Finally the single-command clean up for Python
@@ -14,12 +14,15 @@ bytecode files in your favorite directories. On any platform.
 .. |latest-version| image:: https://img.shields.io/pypi/v/pyclean.svg
    :alt: Latest version on PyPI
    :target: https://pypi.org/project/pyclean
-.. |travis-build| image:: https://img.shields.io/travis/bittner/pyclean/master.svg
-   :alt: Build status
-   :target: https://travis-ci.org/bittner/pyclean
-.. |appveyor-build| image:: https://img.shields.io/appveyor/ci/bittner/pyclean/master.svg
-   :alt: Build status
-   :target: https://ci.appveyor.com/project/bittner/pyclean
+.. |checks-status| image:: https://img.shields.io/github/workflow/status/bittner/pyclean/Checks/master?label=checks
+   :alt: GitHub Workflow Status
+   :target: https://github.com/bittner/pyclean/actions?query=workflow%3AChecks
+.. |tests-status| image:: https://img.shields.io/github/workflow/status/bittner/pyclean/Tests/master?label=tests
+   :alt: GitHub Workflow Status
+   :target: https://github.com/bittner/pyclean/actions?query=workflow%3ATests
+.. |qa| image:: https://img.shields.io/scrutinizer/build/g/bittner/pyclean/master?label=qa
+   :alt: Scrutinizer
+   :target: https://scrutinizer-ci.com/g/bittner/pyclean/
 .. |health| image:: https://img.shields.io/codacy/grade/69de1364a09f41b399f95afe901826eb/master.svg
    :alt: Code health
    :target: https://www.codacy.com/app/bittner/pyclean

--- a/pyclean/py2clean.py
+++ b/pyclean/py2clean.py
@@ -2,10 +2,11 @@
 """
 Python 2 pyclean implementation.
 
-TODO: move it to manpage
 Examples:
-    pyclean -p python-mako # all .py[co] files from the package
-    pyclean /usr/lib/python2.6/dist-packages # python2.6
+    # all .py[co] files from the package
+    pyclean -p python-mako
+    # python2.6
+    pyclean /usr/lib/python2.6/dist-packages
 
 Original source at:
 https://salsa.debian.org/cpython-team/python-defaults/blob/master/pyclean

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands = flake8 {posargs}
 [testenv:pylint]
 description = Check for errors and code smells
 deps = pylint
-commands = pylint {posargs:pyclean setup}
+commands = pylint --rcfile tox.ini {posargs:pyclean setup}
 
 [testenv:readme]
 description = Ensure README renders on PyPI
@@ -66,6 +66,11 @@ exclude = .tox,build,dist,pyclean.egg-info
 per-file-ignores =
     pyclean/py2clean.py:E402
     pyclean/py3clean.py:E402
+
+[pylint]
+[MASTER]
+ignore = py2clean.py,py3clean.py,pypyclean.py
+output-format = colorized
 
 [pytest]
 addopts =


### PR DESCRIPTION
GitHub Actions works differently than other CI services (unless you want to produce spaghetti code with it). :spaghetti: :computer: 

Hence, we'll run the checks (linting and other non-tests) as a separate workflow. :gear: :desktop_computer: 