### PR TITLE
Make PyPy 2+3 run on GitHub Actions

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -25,8 +25,9 @@ def test_clean_package():
         pyclean.cli.main()
 
 
-@pytest.mark.skipif(platform.python_implementation() != 'PyPy',
-                    reason="requires PyPy")
+@pytest.mark.skipif(platform.python_implementation() != 'PyPy'
+                    or platform.system() != 'Linux',
+                    reason="requires PyPy on Debian Linux")
 @patch('pyclean.pypyclean.installed_namespaces', return_value={})
 def test_clean_package_pypy(mock_namespaces):
     """

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -45,8 +45,9 @@ def test_filterversion_py2():
         pyclean.cli.main()
 
 
-@pytest.mark.skipif(platform.python_implementation() != 'PyPy',
-                    reason="requires PyPy")
+@pytest.mark.skipif(platform.python_implementation() != 'PyPy'
+                    or platform.system() != 'Linux',
+                    reason="requires PyPy on Debian Linux")
 @patch('pyclean.pypyclean.installed_namespaces', return_value={})
 def test_filterversion_pypy(mock_namespaces):
     """

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     flake8
     pylint
     bandit
-    py{27,35,36,37,38,py,py3}
+    py{27,35,36,37,38,py2,py3}
     readme
     clean
 
@@ -15,7 +15,7 @@ description = Unit tests
 deps =
     cli-test-helpers
     py27: mock
-    pypy: mock
+    pypy2: mock
     pytest
 commands = pytest
 
@@ -57,6 +57,8 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
+    pypy2: pypy2
+    pypy3: pypy3
 
 [bandit]
 exclude = .tox,build,dist,tests


### PR DESCRIPTION
For some reason PyPy2 and PyPy3 don't run with GitHub Actions. The test execution log is empty.