### PR TITLE
Add metabob badge, reduce other QA badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 pyclean |latest-version|
 ========================
 
-|checks-status| |tests-status| |qa| |health| |python-support| |license|
+|checks-status| |tests-status| |scrutinizer| |codacy| |metabob| |python-support| |license|
 
 Worried about ``.pyc`` files and ``__pycache__`` directories? Fear not!
 Pyclean is here to help. Finally the single-command clean up for Python
@@ -20,12 +20,15 @@ bytecode files in your favorite directories. On any platform.
 .. |tests-status| image:: https://img.shields.io/github/workflow/status/bittner/pyclean/Tests/master?label=Tests&logo=github
    :alt: GitHub Workflow Status
    :target: https://github.com/bittner/pyclean/actions?query=workflow%3ATests
-.. |qa| image:: https://img.shields.io/scrutinizer/build/g/bittner/pyclean/master?label=QA&logo=scrutinizer
+.. |scrutinizer| image:: https://img.shields.io/scrutinizer/build/g/bittner/pyclean/master?logo=scrutinizer&label=%22
    :alt: Scrutinizer
    :target: https://scrutinizer-ci.com/g/bittner/pyclean/
-.. |health| image:: https://img.shields.io/codacy/grade/69de1364a09f41b399f95afe901826eb/master.svg?logo=codacy
+.. |codacy| image:: https://img.shields.io/codacy/grade/69de1364a09f41b399f95afe901826eb/master.svg?logo=codacy&label=%22
    :alt: Code health
    :target: https://www.codacy.com/app/bittner/pyclean
+.. |metabob| image:: https://img.shields.io/badge/⦿-✓-59bfbf.svg?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADIAAAA8CAMAAAAT6xnzAAAAz1BMVEUAAAAAAAD%2F%2F%2F%2BPj4%2BqqqpERET6%2BvqJiYn09PTr6%2BuCgoLS0tJqampQUFAkJCQKCgrg4ODFxcVycnJiYmLLy8tnZ2dMTEw7Ozs2NjalpaWfn593d3daWlpWVlZUVFQsLCwcHBwODg7w8PDc3NzDw8O8vLw%2FPz8fHx8ZGRn39%2Ffm5ubY2NjV1dXPz8%2FIyMi0tLSZmZmFhYUyMjIwMDDj4%2BOUlJRtbW1ISEgiIiISEhLt7e3AwMCvr6%2BdnZ2Hh4ddXV0qKioUFBStra1%2Bfn56enphvz08AAAAAXRSTlMAQObYZgAAArJJREFUSMfVlteWqjAARXPoVaqIvTs69u7c6eX%2Fv%2BkiIkME29Nddz%2BQFcgmyeIkgfz39O4VSktUyTk4VrRtUSxxv3dmWh6ATrJQ%2FF4DRz77u4eA%2FicOfGcIDi5ipwQRV2ieGmVcZUYbeVyHpZXC3cocN7CjlApuwEsaXdzAkiTRcJ3mK6WwuA5P7u6lRCs8riPSSg6XyBW7OlCjlV3ybWO51TLdoo0DxmuLYYZP2NJK%2FfeNLnNEUjlNz0%2FlsLI5XWF6rHSYFMIguLygTivfiLD3TaSkoLKOozxL6mnE3hBhMR2n4G%2FZ9rEH0YDRMFCZGLFDB8ZYlQFfbwLFg8KC77bbJtfgm8BH1nKplVGzLHfIAV97Ywi9vQF8120iICHUeh9RjqAPNYBXXeAxUGaY%2FISJlBVKoeKihs9ykoiSOZ54udECezoTSqHiIiHEnSCkYB4ejsf0svQT2ZAO2RmqeOLf7QpMDgHOICzymeteLoZNBA6sIAhucJ3y9bc%2Fkk4rtVjoYSZwNW%2FekgqHHGj4EoKiVcYHpXix8lLFi8AIzKMGZ7BX%2FrzjvTRd%2B3gtUnOxY4VbFVBdF5Ul%2BMcomxwPoGIJXfq79OPgM7KSA5Cby7%2BplM195RnwsrYkPkikPFJHoUDjAmWSAEfUuMlANttqx7I6I7O1r1uAllTi2ZSZcNIW6%2FD1hoGQvp%2BfSkw3UtIBGAUjE5Eip66jgaX70SVzAWQ4DWpboqaz0XGKEZU%2FKSXNU90TufGjhQMLcn7361eNnqZwanvA7Jki4sJR%2BfC8kgTmyGp7RplRo%2FfWVpQYk1sk9lgaPzWTqj13dvTJR6PcdFjS3LT533tipH9gmncrpIfLOCSNh0v0SRbbC0aDI5nUcA6dnIOtIIPPDbnIW%2BHBSA6ooJTIDRSVyqJeX1aVOflX%2FAUMXjWVQWa95AAAAABJRU5ErkJggg%3D%3D
+   :alt: Visualizer
+   :target: https://metabob.com/bittner/pyclean
 .. |python-support| image:: https://img.shields.io/pypi/pyversions/pyclean.svg
    :alt: Python versions
    :target: https://pypi.org/project/pyclean


### PR DESCRIPTION
Adds a badge for metabob, a new code visualizer service, and makes the other QA service badges a bit shorter.

### Credits

Awesome [logo solution](https://stackoverflow.com/a/41472017/202834) by SO user Claudio.