### PR TITLE
Allow running single test modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - ubuntu-latest
+        - ubuntu-18.04
         - macos-latest
         - windows-latest
         python-version:

--- a/tests/test_modern.py
+++ b/tests/test_modern.py
@@ -13,7 +13,8 @@ except ImportError:  # Python 2.7, PyPy2
 
 from cli_test_helpers import ArgvContext
 
-import pyclean
+import pyclean.cli
+import pyclean.modern
 
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="requires Python 3")

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     py27: mock
     pypy2: mock
     pytest
-commands = pytest
+commands = pytest {posargs}
 
 [testenv:bandit]
 description = PyCQA security linter
@@ -83,5 +83,4 @@ output-format = colorized
 [pytest]
 addopts =
     --color=yes
-    --strict
     --verbose

--- a/tox.ini
+++ b/tox.ini
@@ -21,15 +21,15 @@ commands = pytest {posargs}
 
 [testenv:bandit]
 description = PyCQA security linter
-deps = bandit<1.6.0
-commands = bandit -r . --ini tox.ini
+deps = bandit
+commands = bandit --ini tox.ini {posargs:-r pyclean setup}
 
 [testenv:clean]
 description = Clean up bytecode and build artifacts
 deps = pyclean
 commands =
     pyclean {toxinidir}
-    rm -rf .tox/ build/ dist/ pyclean.egg-info/
+    rm -rf .tox/ build/ dist/ pyclean.egg-info/ .pytest_cache/ pytestdebug.log
 whitelist_externals =
     rm
 

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,11 @@ description = Check for errors and code smells
 deps = pylint
 commands = pylint --rcfile tox.ini {posargs:pyclean setup}
 
+[testenv:license]
+description = Manage license compliance
+deps = reuse
+commands = reuse {posargs:lint}
+
 [testenv:readme]
 description = Ensure README renders on PyPI
 deps = twine


### PR DESCRIPTION
Without explicitly importing modules of the pyclean package they are not found when running tests selectively, e.g.

```console
$ tox -e py39 tests/test_modern.py
```

Fixes #27 