### PR TITLE
Report code coverage for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
         - '3.7'
         - '3.8'
         - '3.9'
-        - pypy2
-        - pypy3
+        - pypy-2.7
+        - pypy-3.7
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
-# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class
-
-# C extensions
-*.so
 
 # Distribution / packaging
 .Python
@@ -25,12 +21,6 @@ wheels/
 *.egg
 MANIFEST
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
@@ -46,40 +36,10 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
+tests/reports/
 
 # pyenv
 .python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# SageMath parsed files
-*.sage.py
 
 # Environments
 .env
@@ -89,16 +49,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
 
 # mypy
 .mypy_cache/

--- a/pyclean/compat.py
+++ b/pyclean/compat.py
@@ -19,6 +19,7 @@ def get_implementation(override=None):
         PyPy3='pyclean.pypyclean',
     )
 
+    # pylint: disable=consider-using-f-string
     detected_version = '%s%s' % (
         platform.python_implementation(),
         sys.version[0],

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ import pyclean as package
 
 def read_file(filename):
     """Get the contents of a file"""
+    # pylint: disable=unspecified-encoding
     with open(join(abspath(dirname(__file__)), filename)) as file:
         return file.read()
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,13 +11,16 @@ envlist =
     clean
 
 [testenv]
-description = Unit tests
+description = Unit tests and test coverage
 deps =
     cli-test-helpers
     py27: mock
     pypy2: mock
-    pytest
-commands = pytest {posargs}
+    pytest-cov
+commands =
+    coverage run --source pyclean -m pytest {posargs}
+    coverage xml -o tests/reports/coverage.xml
+    coverage report
 
 [testenv:bandit]
 description = PyCQA security linter
@@ -83,4 +86,5 @@ output-format = colorized
 [pytest]
 addopts =
     --color=yes
+    --junitxml=tests/reports/unittests.xml
     --verbose


### PR DESCRIPTION
As a convenient feedback from running the unit tests with Tox we now report the code coverage.

We also generate unit test and coverage reports as XML for later use of appropriate tools or platforms (e.g. [test coverage visualization](https://docs.gitlab.com/ee/user/project/merge_requests/test_coverage_visualization.html#python-example) and [unit test reports](https://docs.gitlab.com/ee/ci/unit_test_reports.html#python-example) in GitLab).