### PR TITLE
Fix old-style PyPy config keys (gh-actions Tox plugin)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -66,8 +66,8 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    pypy2: pypy2
-    pypy3: pypy3
+    pypy-2.7: pypy2
+    pypy-3.7: pypy3
 
 [bandit]
 exclude = .tox,build,dist,tests


### PR DESCRIPTION
Addresses the [tox-gh-actions](https://pypi.org/project/tox-gh-actions/) deprecation warning currently being displayed on GitHub:

```
WARNING: PendingDeprecationWarning
Support of old-style PyPy config keys will be removed in tox-gh-actions v3.
Please use "pypy-2" and "pypy-3" instead of "pypy2" and "pypy3".

Example of tox.ini:
[gh-actions]
python =
    pypy-2: pypy2
    pypy-3: pypy3
    # The followings won't work with tox-gh-actions v3
    # pypy2: pypy2
    # pypy3: pypy3
```