### PR TITLE
Pin Python version in GHA (avoids Bandit AST issues)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.7'
     - name: Install prerequisites
       run: python -m pip install --upgrade setuptools pip wheel tox
     - name: Run ${{ matrix.env }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     - name: Install prerequisites
       run: python -m pip install --upgrade pip setuptools twine wheel
     - name: Build package


### PR DESCRIPTION
Specifying the Python version to use in a build job as `'3.x'` calls for brittle behavior and eventual headaches.