### PR TITLE
Fix missing module import guard (top-level code environment)

### DIFF
--- a/pyclean/__main__.py
+++ b/pyclean/__main__.py
@@ -1,6 +1,7 @@
 """
 Main entry point for running pyclean as a module.
 """
-from . import cli
+from .cli import main
 
-cli.main()
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The missing guard for module imports went unnoticed until now. It would have popped up if we had started using doctests, because that would try to import each module and would have hence executed the main entry point unwanted.