### PR TITLE
Upload coverage report, use CLI test helpers shell, use latest Bandit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,8 @@ jobs:
       run: python -m pip install --upgrade setuptools pip wheel tox-gh-actions
     - name: Run tests
       run: tox
+    - name: Upload coverage report
+      uses: codacy/codacy-coverage-reporter-action@master
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: tests/coverage-report.xml

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,8 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
-tests/reports/
+tests/*-report.json
+tests/*-report.xml
 
 # pyenv
 .python-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,27 +1,12 @@
 [tool.bandit]
-# Exclude/ignore of files is currently broken in Bandit:
-# https://github.com/PyCQA/bandit/issues/693
-# https://github.com/PyCQA/bandit/issues/490
-# https://github.com/PyCQA/bandit/issues/438#issuecomment-494211922
-#
-# Reading settings from configuration files is broken:
-# https://github.com/PyCQA/bandit/issues/753
-# https://github.com/PyCQA/bandit/issues/595
-#
-# Reading from pyproject.toml not yet functional:
-# Must install "toml" package and use "-c pyproject.toml".
-# https://github.com/PyCQA/bandit/issues/758
-#
-# INI file configuration and CLI usage is unclear:
-# https://github.com/PyCQA/bandit/issues/603
-# https://github.com/PyCQA/bandit/issues/467
-# https://github.com/PyCQA/bandit/issues/396
+# NOTE: Exclude/ignore of files is currently broken in Bandit
+exclude = [".git",".github",".tox","py2clean.py","py3clean.py","pypyclean.py","tests"]
 
 [tool.black]
 color = true
 
 [tool.coverage.xml]
-output = "tests/reports/coverage.xml"
+output = "tests/coverage-report.xml"
 
 [tool.isort]
 color_output = true
@@ -32,4 +17,4 @@ ignore = ["py2clean.py","py3clean.py","pypyclean.py"]
 output-format = "colorized"
 
 [tool.pytest.ini_options]
-addopts = "--junitxml=tests/reports/unittests.xml --color=yes --verbose"
+addopts = "--junitxml=tests/unittests-report.xml --color=yes --verbose"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,13 +2,14 @@
 Tests for the pyclean CLI
 """
 import os
+import platform
 
 try:
     from unittest.mock import patch
 except ImportError:  # Python 2.7, PyPy2
     from mock import patch
 
-from cli_test_helpers import ArgvContext
+from cli_test_helpers import ArgvContext, shell
 
 import pyclean.cli
 
@@ -17,16 +18,16 @@ def test_entrypoint():
     """
     Is entrypoint script installed? (setup.py)
     """
-    exit_status = os.system('pyclean --help')
-    assert exit_status == 0
+    result = shell('pyclean --help')
+    assert result.exit_code == 0
 
 
 def test_entrypoint_py2_installed():
     """
     Is entrypoint script installed for Python 2? (setup.py)
     """
-    exit_status = os.system('py2clean --help')
-    assert exit_status == 0
+    result = shell('py2clean --help')
+    assert result.exit_code == 0
 
 
 @patch('pyclean.compat.import_module')
@@ -45,8 +46,8 @@ def test_entrypoint_py3_installed():
     """
     Is entrypoint script installed for Python 3? (setup.py)
     """
-    exit_status = os.system('py3clean --help')
-    assert exit_status == 0
+    result = shell('py3clean --help')
+    assert result.exit_code == 0
 
 
 @patch('pyclean.compat.import_module')
@@ -65,8 +66,8 @@ def test_entrypoint_pypy_installed():
     """
     Is entrypoint script installed for PyPy 2/3? (setup.py)
     """
-    exit_status = os.system('pypyclean --help')
-    assert exit_status == 0
+    result = shell('pypyclean --help')
+    assert result.exit_code == 0
 
 
 @patch('pyclean.compat.import_module')
@@ -79,6 +80,22 @@ def test_entrypoint_pypy_working(mock_import_module):
 
     args, _ = mock_import_module.call_args
     assert args == ('pyclean.pypyclean',)
+
+
+def test_version_option():
+    """
+    Does --version yield the expected information?
+    """
+    expected_output = '' if platform.python_version_tuple() < ('3',) \
+        else '%s%s' % (
+            pyclean.__version__,
+            os.linesep
+        )
+
+    result = shell('pyclean --version')
+
+    assert result.stdout == expected_output
+    assert result.exit_code == 0
 
 
 @patch('pyclean.compat.get_implementation')

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ commands =
 
 [testenv:bandit]
 description = PyCQA security linter
-deps = bandit<1.6
-commands = bandit --ini tox.ini {posargs:-r .}
+deps = bandit
+commands = bandit {posargs:-r pyclean} -v --exclude py2clean,py3clean,pypyclean
 
 [testenv:black]
 description = Ensure consistent code style
@@ -39,7 +39,7 @@ description = Clean up bytecode and build artifacts
 deps = pyclean
 commands =
     pyclean {toxinidir}
-    rm -rf .coverage .tox/ build/ dist/ pyclean.egg-info/ .pytest_cache/ pytestdebug.log
+    rm -rf .coverage .tox/ build/ dist/ pyclean.egg-info/ .pytest_cache/ pytestdebug.log tests/coverage-report.xml tests/unittests-report.xml
 allowlist_externals =
     rm
 
@@ -69,9 +69,6 @@ deps = twine
 commands =
     {envpython} setup.py -q sdist bdist_wheel
     twine check dist/*
-
-[bandit]
-exclude = .git,.github,.tox,py2clean.py,py3clean.py,pypyclean.py,tests
 
 [flake8]
 exclude = .tox,build,dist,pyclean.egg-info


### PR DESCRIPTION
Uploads coverage data generated with unit test execution to Codacy.

Implementation information comes from:

- https://docs.codacy.com/coverage-reporter/#uploading-coverage
- https://github.com/codacy/codacy-coverage-reporter