### PR TITLE
Speed up linting (Tox jobs)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,8 +132,9 @@ If you want to avoid installing ``pyclean`` you can add it to your
 .. code:: ini
 
     [testenv:clean]
+    skip_install = true
     deps = pyclean
-    commands = pyclean {toxinidir}
+    commands = pyclean {posargs:.}
 
 You'll then be able to run it with `Tox`_ like this:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ exclude = [".git",".github",".tox","py2clean.py","py3clean.py","pypyclean.py","t
 [tool.black]
 color = true
 
+[tool.coverage.run]
+source = ["pyclean"]
+
 [tool.coverage.xml]
 output = "tests/coverage-report.xml"
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,36 +32,41 @@ deps =
     coverage[toml]
     pytest
 commands =
-    coverage run --source pyclean -m pytest {posargs}
+    coverage run -m pytest {posargs}
     coverage xml
     coverage report
 
 [testenv:bandit]
 description = PyCQA security linter
+skip_install = true
 deps = bandit
 commands = bandit {posargs:-r pyclean} -v --exclude py2clean,py3clean,pypyclean
 
 [testenv:black]
 description = Ensure consistent code style
+skip_install = true
 deps = black
 commands = black --check --diff {posargs:pyclean setup.py tests}
 
 [testenv:clean]
 description = Clean up bytecode and build artifacts
+skip_install = true
 deps = pyclean
 commands =
-    pyclean {toxinidir}
+    pyclean {posargs:.}
     rm -rf .coverage .tox/ build/ dist/ pyclean.egg-info/ .pytest_cache/ pytestdebug.log tests/coverage-report.xml tests/unittests-report.xml
 allowlist_externals =
     rm
 
 [testenv:flake8]
 description = Static code analysis and code style
+skip_install = true
 deps = flake8
 commands = flake8 {posargs}
 
 [testenv:isort]
 description = Ensure imports are ordered consistently
+skip_install = true
 deps = isort[colors]
 commands = isort --check-only --diff {posargs:pyclean setup tests}
 
@@ -72,11 +77,13 @@ commands = pylint {posargs:pyclean setup}
 
 [testenv:license]
 description = Manage license compliance
+skip_install = true
 deps = reuse
 commands = reuse {posargs:lint}
 
 [testenv:readme]
 description = Ensure README renders on PyPI
+skip_install = true
 deps =
     build
     twine


### PR DESCRIPTION
The [`skip_install` option](https://tox.wiki/en/latest/config.html?highlight=skip_install#conf-skip_install) controls whether to install the software from the repository in the virtual environment. This is unneeded for all linting jobs, except Pylint. Hence, we can save developers a lot of time.