### PR TITLE
Add `--ignore` option, initialize logging centrally

### DIFF
--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -2,8 +2,11 @@
 Command line interface implementation for pyclean.
 """
 import argparse
+import logging
 
 from . import __version__, compat, modern
+
+log = logging.getLogger(__name__)
 
 
 def parse_arguments():
@@ -11,7 +14,8 @@ def parse_arguments():
     Parse and handle CLI arguments
     """
     parser = argparse.ArgumentParser(
-        description='Remove byte-compiled files for a package')
+        description='Remove byte-compiled files for a package',
+    )
 
     parser.add_argument('--version', action='version', version=__version__)
     parser.add_argument('-V', metavar='VERSION', dest='version',
@@ -22,6 +26,11 @@ def parse_arguments():
                              '(may be specified multiple times)')
     parser.add_argument('directory', nargs='*',
                         help='Directory tree (or file) to byte-compile')
+    parser.add_argument('-i', '--ignore', metavar='DIRECTORY',
+                        action='append', default=['.git', '.tox', '.venv'],
+                        help='Directory that should be ignored '
+                             '(may be specified multiple times; '
+                             'default: %(default)s)')
     parser.add_argument('--legacy', action='store_true',
                         help='Use legacy Debian implementation (autodetect)')
     parser.add_argument('-n', '--dry-run', action='store_true',
@@ -34,11 +43,56 @@ def parse_arguments():
                            help='Be more verbose')
 
     args = parser.parse_args()
+    init_logging(args)
 
     if not (args.package or args.directory):
         parser.error('A directory (or files) or a list of packages '
                      'must be specified.')
+
+    args.ignore = parse_ignore_list(args.ignore)
+    log.debug("Ignored directories: %s", ','.join(args.ignore))
+
     return args
+
+
+def parse_ignore_list(directory_list):
+    """
+    Split up and reintegrate folder names in values having a comma-separated
+    list of directory names.
+
+    >>> parse_ignore_list(['a,b,c'])
+    ['a', 'b', 'c']
+    >>> parse_ignore_list(['a', 'b,c'])
+    ['a', 'b', 'c']
+    >>> parse_ignore_list(['a , b, c'])
+    ['a', 'b', 'c']
+    >>> parse_ignore_list([',,a,,,b,,'])
+    ['a', 'b']
+    >>> parse_ignore_list([',a', 'b,'])
+    ['a', 'b']
+    """
+    ignore_list = []
+
+    for dirname in directory_list:
+        if ',' not in dirname:
+            ignore_list += [dirname]
+        else:
+            ignore_list += [
+                token.strip() for token in dirname.split(',') if token.strip()
+            ]
+
+    return sorted(list(set(ignore_list)))
+
+
+def init_logging(args):
+    """
+    Set the log level according to the -v/-q command line options.
+    """
+    log_level = logging.FATAL if args.quiet \
+        else logging.DEBUG if args.verbose \
+        else logging.INFO
+    log_format = "%(message)s"
+    logging.basicConfig(level=log_level, format=log_format)
 
 
 def main(override=None):

--- a/pyclean/modern.py
+++ b/pyclean/modern.py
@@ -58,12 +58,7 @@ def pyclean(args):
     """Cross-platform cleaning of Python bytecode."""
     Runner.unlink = print_filename if args.dry_run else remove_file
     Runner.rmdir = print_dirname if args.dry_run else remove_directory
-
-    log_level = logging.FATAL if args.quiet \
-        else logging.DEBUG if args.verbose \
-        else logging.INFO
-    log_format = "%(message)s"
-    logging.basicConfig(level=log_level, format=log_format)
+    Runner.ignore = args.ignore
 
     for directory in args.directory:
         log.info("Cleaning directory %s", directory)
@@ -88,7 +83,10 @@ def descend_and_clean_bytecode(directory):
             if child.suffix in ['.pyc', '.pyo']:
                 Runner.unlink(child)
         elif child.is_dir():
-            descend_and_clean_bytecode(child)
+            if child.name in Runner.ignore:
+                log.debug("Skipping %s", child)
+            else:
+                descend_and_clean_bytecode(child)
 
             if child.name == '__pycache__':
                 Runner.rmdir(child)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,4 @@ ignore = ["py2clean.py","py3clean.py","pypyclean.py"]
 output-format = "colorized"
 
 [tool.pytest.ini_options]
-addopts = "--junitxml=tests/unittests-report.xml --color=yes --verbose"
+addopts = "--doctest-modules --ignore=pyclean/py2clean.py --ignore=pyclean/py3clean.py --ignore=pyclean/pypyclean.py --junitxml=tests/unittests-report.xml --color=yes --verbose"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,12 +3,14 @@ Tests for the pyclean CLI
 """
 import os
 import platform
+import sys
 
 try:
     from unittest.mock import patch
 except ImportError:  # Python 2.7, PyPy2
     from mock import patch
 
+import pytest
 from cli_test_helpers import ArgvContext, shell
 
 import pyclean.cli
@@ -80,6 +82,29 @@ def test_entrypoint_pypy_working(mock_import_module):
 
     args, _ = mock_import_module.call_args
     assert args == ('pyclean.pypyclean',)
+
+
+@pytest.mark.skipif(sys.version_info < (3,), reason="requires Python 3")
+def test_dryrun_option():
+    """
+    Does a --dry-run option exist?
+    """
+    result = shell('pyclean --dry-run tests')
+
+    assert result.exit_code == 0
+
+
+def test_ignore_option():
+    """
+    Does an --ignore option exist and append values to a list of defaults?
+    """
+    default = ['.git', '.tox', '.venv']
+    expected_ignore_list = default + ['foo']
+
+    with ArgvContext('pyclean', '.', '--ignore', 'foo'):
+        args = pyclean.cli.parse_arguments()
+
+    assert args.ignore == expected_ignore_list
 
 
 def test_version_option():


### PR DESCRIPTION
A new `--ignore` option specifies a list for directories that shall be skipped when walking the directory tree. The option has a set of typical folders as a default. That default is extended by using `--ignore` on the command line.

Fixes #21.