### PR TITLE
Activate color output on GHA, re-add Pytest config for 2.7

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+env:
+  PY_COLORS: "1"
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -24,7 +27,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install build tools
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,12 @@
-name: Publish Python package
+name: Publish
 
 on:
   push:
     tags:
     - "*"
+
+env:
+  PY_COLORS: "1"
 
 jobs:
   publish:
@@ -12,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install build tools
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+env:
+  PY_COLORS: "1"
+
 jobs:
   test:
     runs-on: ${{ matrix.platform }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,4 @@ ignore = ["py2clean.py","py3clean.py","pypyclean.py"]
 output-format = "colorized"
 
 [tool.pytest.ini_options]
-addopts = "--doctest-modules --ignore=pyclean/py2clean.py --ignore=pyclean/py3clean.py --ignore=pyclean/pypyclean.py --junitxml=tests/unittests-report.xml --color=yes --verbose"
+addopts = "--color=yes --doctest-modules --ignore=pyclean/py2clean.py --ignore=pyclean/py3clean.py --ignore=pyclean/pypyclean.py --junitxml=tests/unittests-report.xml --verbose"

--- a/tox.ini
+++ b/tox.ini
@@ -96,3 +96,13 @@ exclude = .tox,build,dist,pyclean.egg-info
 per-file-ignores =
     pyclean/py2clean.py:E402
     pyclean/py3clean.py:E402
+
+[pytest]
+addopts =
+    --color=yes
+    --doctest-modules
+    --ignore=pyclean/py2clean.py
+    --ignore=pyclean/py3clean.py
+    --ignore=pyclean/pypyclean.py
+    --junitxml=tests/unittests-report.xml
+    --verbose


### PR DESCRIPTION
As mentioned in https://github.com/pytest-dev/pytest/issues/7443, we need to force Python tooling on GHA to use colors, because they don't detect the GHA console as a TTY.

In addition, we add Pytest configuration to `tox.ini` again (in addition to `pyproject.toml`), so that output for Python 2.7 looks like the one of the tests with Python 3 versions.