### PR TITLE
Add `--debris` CLI option for choosing cleanup targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - ubuntu-latest
+        - ubuntu-20.04
         - macos-latest
         - windows-latest
         python-version:
@@ -29,6 +29,7 @@ jobs:
         - '3.8'
         - '3.9'
         - '3.10'
+        - '3.11'
         - pypy-2.7
         - pypy-3.7
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,4 +45,4 @@ jobs:
       uses: codacy/codacy-coverage-reporter-action@master
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: tests/coverage-report.xml
+        coverage-reports: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -32,12 +32,12 @@ htmlcov/
 .coverage.*
 .cache
 nosetests.xml
+coverage.json
 coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
-tests/*-report.json
-tests/*-report.xml
+tests/junit-report.xml
 
 # pyenv
 .python-version

--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,10 @@ bytecode files in your favorite directories. On any platform.
 .. |latest-version| image:: https://img.shields.io/pypi/v/pyclean.svg
    :target: https://pypi.org/project/pyclean
    :alt: Latest version on PyPI
-.. |checks-status| image:: https://img.shields.io/github/workflow/status/bittner/pyclean/Checks/main?label=Checks&logo=github
+.. |checks-status| image:: https://img.shields.io/github/actions/workflow/status/bittner/pyclean/check.yml?branch=main&label=Checks&logo=github
    :target: https://github.com/bittner/pyclean/actions/workflows/check.yml
    :alt: GitHub Workflow Status
-.. |tests-status| image:: https://img.shields.io/github/workflow/status/bittner/pyclean/Tests/main?label=Tests&logo=github
+.. |tests-status| image:: https://img.shields.io/github/actions/workflow/status/bittner/pyclean/test.yml?branch=main&label=Tests&logo=github
    :target: https://github.com/bittner/pyclean/actions/workflows/test.yml
    :alt: GitHub Workflow Status
 .. |scrutinizer| image:: https://img.shields.io/scrutinizer/build/g/bittner/pyclean/main?logo=scrutinizer&label=%22

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 pyclean |latest-version|
 ========================
 
-|checks-status| |tests-status| |scrutinizer| |codacy| |metabob| |python-support| |license|
+|checks-status| |tests-status| |scrutinizer| |codacy| |python-versions| |python-impl| |license|
 
 Worried about ``.pyc`` files and ``__pycache__`` directories? Fear not!
 PyClean is here to help. Finally the single-command clean up for Python
@@ -26,12 +26,12 @@ bytecode files in your favorite directories. On any platform.
 .. |codacy| image:: https://img.shields.io/codacy/grade/69de1364a09f41b399f95afe901826eb/main.svg?logo=codacy&label=%22
    :target: https://app.codacy.com/gh/bittner/pyclean/dashboard
    :alt: Code health
-.. |metabob| image:: https://img.shields.io/badge/⦿-✓-59bfbf.svg?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADIAAAA8CAMAAAAT6xnzAAAAz1BMVEUAAAAAAAD%2F%2F%2F%2BPj4%2BqqqpERET6%2BvqJiYn09PTr6%2BuCgoLS0tJqampQUFAkJCQKCgrg4ODFxcVycnJiYmLLy8tnZ2dMTEw7Ozs2NjalpaWfn593d3daWlpWVlZUVFQsLCwcHBwODg7w8PDc3NzDw8O8vLw%2FPz8fHx8ZGRn39%2Ffm5ubY2NjV1dXPz8%2FIyMi0tLSZmZmFhYUyMjIwMDDj4%2BOUlJRtbW1ISEgiIiISEhLt7e3AwMCvr6%2BdnZ2Hh4ddXV0qKioUFBStra1%2Bfn56enphvz08AAAAAXRSTlMAQObYZgAAArJJREFUSMfVlteWqjAARXPoVaqIvTs69u7c6eX%2Fv%2BkiIkME29Nddz%2BQFcgmyeIkgfz39O4VSktUyTk4VrRtUSxxv3dmWh6ATrJQ%2FF4DRz77u4eA%2FicOfGcIDi5ipwQRV2ieGmVcZUYbeVyHpZXC3cocN7CjlApuwEsaXdzAkiTRcJ3mK6WwuA5P7u6lRCs8riPSSg6XyBW7OlCjlV3ybWO51TLdoo0DxmuLYYZP2NJK%2FfeNLnNEUjlNz0%2FlsLI5XWF6rHSYFMIguLygTivfiLD3TaSkoLKOozxL6mnE3hBhMR2n4G%2FZ9rEH0YDRMFCZGLFDB8ZYlQFfbwLFg8KC77bbJtfgm8BH1nKplVGzLHfIAV97Ywi9vQF8120iICHUeh9RjqAPNYBXXeAxUGaY%2FISJlBVKoeKihs9ykoiSOZ54udECezoTSqHiIiHEnSCkYB4ejsf0svQT2ZAO2RmqeOLf7QpMDgHOICzymeteLoZNBA6sIAhucJ3y9bc%2Fkk4rtVjoYSZwNW%2FekgqHHGj4EoKiVcYHpXix8lLFi8AIzKMGZ7BX%2FrzjvTRd%2B3gtUnOxY4VbFVBdF5Ul%2BMcomxwPoGIJXfq79OPgM7KSA5Cby7%2BplM195RnwsrYkPkikPFJHoUDjAmWSAEfUuMlANttqx7I6I7O1r1uAllTi2ZSZcNIW6%2FD1hoGQvp%2BfSkw3UtIBGAUjE5Eip66jgaX70SVzAWQ4DWpboqaz0XGKEZU%2FKSXNU90TufGjhQMLcn7361eNnqZwanvA7Jki4sJR%2BfC8kgTmyGp7RplRo%2FfWVpQYk1sk9lgaPzWTqj13dvTJR6PcdFjS3LT533tipH9gmncrpIfLOCSNh0v0SRbbC0aDI5nUcA6dnIOtIIPPDbnIW%2BHBSA6ooJTIDRSVyqJeX1aVOflX%2FAUMXjWVQWa95AAAAABJRU5ErkJggg%3D%3D
-   :target: https://metabob.com/github/bittner/pyclean
-   :alt: Visualizer
-.. |python-support| image:: https://img.shields.io/pypi/pyversions/pyclean.svg
+.. |python-versions| image:: https://img.shields.io/pypi/pyversions/pyclean.svg
    :target: https://pypi.org/project/pyclean
    :alt: Python versions
+.. |python-impl| image:: https://img.shields.io/pypi/implementation/pyclean.svg
+   :target: https://pypi.org/project/pyclean
+   :alt: Python implementations
 .. |license| image:: https://img.shields.io/pypi/l/pyclean.svg
    :target: https://github.com/bittner/pyclean/blob/main/LICENSE
    :alt: Software license

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ pyclean |latest-version|
 |checks-status| |tests-status| |scrutinizer| |codacy| |metabob| |python-support| |license|
 
 Worried about ``.pyc`` files and ``__pycache__`` directories? Fear not!
-Pyclean is here to help. Finally the single-command clean up for Python
+PyClean is here to help. Finally the single-command clean up for Python
 bytecode files in your favorite directories. On any platform.
 
 |video|

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -3,6 +3,7 @@ Command line interface implementation for pyclean.
 """
 import argparse
 import logging
+import sys
 
 from . import __version__, compat, modern
 
@@ -19,6 +20,9 @@ def parse_arguments():
     parser = argparse.ArgumentParser(
         description='Remove byte-compiled files for a package or project.',
     )
+
+    if sys.version_info < (3, 8):
+        parser.register('action', 'extend', compat.ExtendAction)
 
     parser.add_argument('--version', action='version', version=__version__)
     parser.add_argument('-V', metavar='VERSION', dest='version',

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -16,6 +16,7 @@ def parse_arguments():
     """
     debris_default_topics = ['build', 'cache', 'coverage', 'pytest']
     debris_optional_topics = ['tox']
+    ignore_default_items = ['.git', '.tox', '.venv']
 
     parser = argparse.ArgumentParser(
         description='Remove byte-compiled files for a package or project.',
@@ -34,16 +35,16 @@ def parse_arguments():
     parser.add_argument('directory', nargs='*',
                         help='directory tree to traverse for byte-code')
     parser.add_argument('-i', '--ignore', metavar='DIRECTORY', action='extend',
-                        nargs='+', default=['.git', '.tox', '.venv'],
+                        nargs='+', default=ignore_default_items,
                         help='directory that should be ignored '
                              '(may be specified multiple times; '
-                             'default: %(default)s)')
+                             'default: %s)' % ' '.join(ignore_default_items))
     parser.add_argument('-d', '--debris', metavar='TOPIC', action='extend',
                         nargs='*', default=argparse.SUPPRESS,
                         choices=debris_default_topics + debris_optional_topics,
-                        help='remove typical leftovers from well-known '
-                             'programs (may be specified multiple times; '
-                             'default: %s)' % debris_default_topics)
+                        help='remove leftovers from popular Python development '
+                             'tools (may be specified multiple times; '
+                             'default: %s)' % ' '.join(debris_default_topics))
     parser.add_argument('--legacy', action='store_true',
                         help='use legacy Debian implementation (autodetect)')
     parser.add_argument('-n', '--dry-run', action='store_true',

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -16,7 +16,7 @@ def parse_arguments():
     debris_default_topics = ['build', 'cache', 'coverage', 'pytest']
 
     parser = argparse.ArgumentParser(
-        description='Remove byte-compiled files for a package',
+        description='Remove byte-compiled files for a package or project.',
     )
 
     parser.add_argument('--version', action='version', version=__version__)
@@ -27,28 +27,28 @@ def parse_arguments():
                         help='Debian package to byte-compile '
                              '(may be specified multiple times)')
     parser.add_argument('directory', nargs='*',
-                        help='Directory tree (or file) to byte-compile')
+                        help='directory tree to traverse for byte-code')
     parser.add_argument('-i', '--ignore', metavar='DIRECTORY', action='extend',
                         nargs='+', default=['.git', '.tox', '.venv'],
-                        help='Directory that should be ignored '
+                        help='directory that should be ignored '
                              '(may be specified multiple times; '
                              'default: %(default)s)')
     parser.add_argument('-d', '--debris', metavar='TOPIC', action='extend',
                         nargs='*', default=argparse.SUPPRESS,
                         choices=debris_default_topics,
-                        help='Removes typical leftovers from well-known '
+                        help='remove typical leftovers from well-known '
                              'programs (may be specified multiple times; '
                              'default: %s)' % debris_default_topics)
     parser.add_argument('--legacy', action='store_true',
-                        help='Use legacy Debian implementation (autodetect)')
+                        help='use legacy Debian implementation (autodetect)')
     parser.add_argument('-n', '--dry-run', action='store_true',
-                        help='Show what would be done')
+                        help='show what would be done')
 
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument('-q', '--quiet', action='store_true',
-                           help='Be quiet')
+                           help='be quiet')
     verbosity.add_argument('-v', '--verbose', action='store_true',
-                           help='Be more verbose')
+                           help='be more verbose')
 
     args = parser.parse_args()
     init_logging(args)

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -14,6 +14,7 @@ def parse_arguments():
     Parse and handle CLI arguments
     """
     debris_default_topics = ['build', 'cache', 'coverage', 'pytest']
+    debris_optional_topics = ['tox']
 
     parser = argparse.ArgumentParser(
         description='Remove byte-compiled files for a package or project.',
@@ -35,7 +36,7 @@ def parse_arguments():
                              'default: %(default)s)')
     parser.add_argument('-d', '--debris', metavar='TOPIC', action='extend',
                         nargs='*', default=argparse.SUPPRESS,
-                        choices=debris_default_topics,
+                        choices=debris_default_topics + debris_optional_topics,
                         help='remove typical leftovers from well-known '
                              'programs (may be specified multiple times; '
                              'default: %s)' % debris_default_topics)
@@ -61,6 +62,8 @@ def parse_arguments():
         if args.debris == []:
             args.debris = debris_default_topics
         log.debug("Debris requested to clean up for: %s", ' '.join(args.debris))
+    else:
+        args.debris = []
 
     log.debug("Ignored directories: %s", ' '.join(args.ignore))
 

--- a/pyclean/compat.py
+++ b/pyclean/compat.py
@@ -3,6 +3,7 @@ Cross-Python version compatibility.
 """
 import platform
 import sys
+from argparse import _AppendAction as AppendAction
 from importlib import import_module
 
 
@@ -26,3 +27,16 @@ def get_implementation(override=None):
 
     module_name = implementation[override if override else detected_version]
     return import_module(module_name)
+
+
+class ExtendAction(AppendAction):
+    """
+    Argparse "extend" action for Python < 3.8.
+    A simplified backport from the Python standard library.
+    """
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        items = getattr(namespace, self.dest, None)
+        items = [] if items is None else items[:]
+        items.extend(values)
+        setattr(namespace, self.dest, items)

--- a/pyclean/compat.py
+++ b/pyclean/compat.py
@@ -19,7 +19,6 @@ def get_implementation(override=None):
         PyPy3='pyclean.pypyclean',
     )
 
-    # pylint: disable=consider-using-f-string
     detected_version = '%s%s' % (
         platform.python_implementation(),
         sys.version[0],

--- a/pyclean/modern.py
+++ b/pyclean/modern.py
@@ -13,24 +13,24 @@ BYTECODE_FILES = ['.pyc', '.pyo']
 BYTECODE_DIRS = ['__pycache__']
 DEBRIS_TOPICS = {
     'build': [
-        'dist/',
-        'sdist/',
-        '*.egg-info/',
+        'dist/**',
+        'sdist/**',
+        '*.egg-info/**',
     ],
     'cache': [
-        '.cache/',
+        '.cache/**',
     ],
     'coverage': [
         '.coverage',
         'coverage.json',
         'coverage.xml',
-        'htmlcov/',
+        'htmlcov/**',
     ],
     'pytest': [
-        '.pytest_cache/',
+        '.pytest_cache/**',
     ],
     'tox': [
-        '.tox/',
+        '.tox/**',
     ],
 }
 

--- a/pyclean/modern.py
+++ b/pyclean/modern.py
@@ -64,6 +64,9 @@ def pyclean(args):
         log.info("Cleaning directory %s", directory)
         descend_and_clean_bytecode(Path(directory))
 
+    for topic in args.debris:
+        remove_debris_for(topic)
+
     log.info("Total %d files, %d directories %s.",
              Runner.unlink_count, Runner.rmdir_count,
              "would be removed" if args.dry_run else "removed")
@@ -92,3 +95,36 @@ def descend_and_clean_bytecode(directory):
                 Runner.rmdir(child)
         else:
             log.debug("Ignoring %s", child)
+
+
+def remove_debris_for(topic):
+    """
+    Clean up debris for a specific topic.
+    """
+    topics = {
+        'build': [
+            'dist',
+            'sdist',
+            '*.egg-info',
+        ],
+        'cache': [
+            '.cache',
+        ],
+        'coverage': [
+            '.coverage',
+            'coverage.json',
+            'coverage.xml',
+            'htmlcov',
+        ],
+        'pytest': [
+            '.pytest_cache',
+        ],
+        'tox': [
+            '.tox',
+        ],
+    }
+
+    log.debug("Cleaning up debris for %s ...", topic)
+
+    for pathname in topics[topic]:
+        log.debug(pathname)

--- a/pyclean/modern.py
+++ b/pyclean/modern.py
@@ -9,6 +9,8 @@ except ImportError:  # Python 2.7, PyPy2
     from warnings import warn
     warn("Python 3 required for modern implementation. Python 2 is obsolete.")
 
+BYTECODE_FILES = ['.pyc', '.pyo']
+BYTECODE_DIRS = ['__pycache__']
 DEBRIS_TOPICS = {
     'build': [
         'dist/',
@@ -83,14 +85,11 @@ def pyclean(args):
     Runner.rmdir = print_dirname if args.dry_run else remove_directory
     Runner.ignore = args.ignore
 
-    bytecode_files = ['.pyc', '.pyo']
-    bytecode_dirs = ['__pycache__']
-
     for dir_name in args.directory:
         directory = Path(dir_name)
 
         log.info("Cleaning directory %s", directory)
-        descend_and_clean(directory, bytecode_files, bytecode_dirs)
+        descend_and_clean(directory, BYTECODE_FILES, BYTECODE_DIRS)
 
     for topic in args.debris:
         remove_debris_for(topic, directory)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ color_output = true
 profile = "black"
 
 [tool.pylint.master]
+disable = ["consider-using-f-string"]
 ignore = ["py2clean.py","py3clean.py","pypyclean.py"]
 output-format = "colorized"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ color = true
 [tool.coverage.run]
 source = ["pyclean"]
 
-[tool.coverage.xml]
-output = "tests/coverage-report.xml"
+[tool.coverage.report]
+show_missing = true
 
 [tool.isort]
 color_output = true
@@ -19,4 +19,4 @@ ignore = ["py2clean.py","py3clean.py","pypyclean.py"]
 output-format = "colorized"
 
 [tool.pytest.ini_options]
-addopts = "--color=yes --doctest-modules --ignore=pyclean/py2clean.py --ignore=pyclean/py3clean.py --ignore=pyclean/pypyclean.py --junitxml=tests/unittests-report.xml --verbose"
+addopts = "--color=yes --doctest-modules --ignore=pyclean/py2clean.py --ignore=pyclean/py3clean.py --ignore=pyclean/pypyclean.py --junitxml=tests/junit-report.xml --verbose"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Packaging setup for pyclean
 """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -127,6 +127,15 @@ def test_debris_explicit_args():
     assert args.debris == ['build', 'pytest']
 
 
+def test_debris_invalid_args():
+    """
+    Does calling `pyclean --debris` with invalid arguments abort execution?
+    """
+    with ArgvContext('pyclean', 'foo', '--debris', 'not-a-tool-name'), \
+            pytest.raises(SystemExit):
+        pyclean.cli.parse_arguments()
+
+
 def test_version_option():
     """
     Does --version yield the expected information?

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,12 +99,32 @@ def test_ignore_option():
     Does an --ignore option exist and append values to a list of defaults?
     """
     default = ['.git', '.tox', '.venv']
-    expected_ignore_list = default + ['foo']
+    expected_ignore_list = default + ['foo', 'bar']
 
-    with ArgvContext('pyclean', '.', '--ignore', 'foo'):
+    with ArgvContext('pyclean', '.', '--ignore', 'foo', 'bar'):
         args = pyclean.cli.parse_arguments()
 
     assert args.ignore == expected_ignore_list
+
+
+def test_debris_default_args():
+    """
+    Does calling `pyclean --debris` use defaults for the debris option?
+    """
+    with ArgvContext('pyclean', 'foo', '--debris'):
+        args = pyclean.cli.parse_arguments()
+
+    assert args.debris == ['build', 'cache', 'coverage', 'pytest']
+
+
+def test_debris_explicit_args():
+    """
+    Does calling `pyclean --debris` with explicit arguments provide those?
+    """
+    with ArgvContext('pyclean', 'foo', '--debris', 'build', 'pytest'):
+        args = pyclean.cli.parse_arguments()
+
+    assert args.debris == ['build', 'pytest']
 
 
 def test_version_option():
@@ -112,10 +132,7 @@ def test_version_option():
     Does --version yield the expected information?
     """
     expected_output = '' if platform.python_version_tuple() < ('3',) \
-        else '%s%s' % (
-            pyclean.__version__,
-            os.linesep
-        )
+        else '%s%s' % (pyclean.__version__, os.linesep)
 
     result = shell('pyclean --version')
 
@@ -128,7 +145,7 @@ def test_legacy_calls_compat(mock_get_implementation):
     """
     Does calling `pyclean --legacy` invoke the compat layer?
     """
-    with ArgvContext('pyclean', '--legacy', 'foo'):
+    with ArgvContext('pyclean', 'foo', '--legacy'):
         pyclean.cli.main()
 
     assert mock_get_implementation.called

--- a/tests/test_modern.py
+++ b/tests/test_modern.py
@@ -19,7 +19,7 @@ import pyclean.modern
 
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="requires Python 3")
-@patch('pyclean.modern.descend_and_clean_bytecode')
+@patch('pyclean.modern.descend_and_clean')
 def test_walks_tree(mock_descend):
     """
     Does pyclean walk the directory tree?
@@ -28,12 +28,12 @@ def test_walks_tree(mock_descend):
         pyclean.cli.main()
 
     assert mock_descend.mock_calls == [
-        call(Path('.')),
+        call(Path('.'), ['.pyc', '.pyo'], ['__pycache__']),
     ]
 
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="requires Python 3")
-@patch('pyclean.modern.descend_and_clean_bytecode')
+@patch('pyclean.modern.descend_and_clean')
 def test_walks_all_trees(mock_descend):
     """
     Are all positional args evaluated?
@@ -42,15 +42,15 @@ def test_walks_all_trees(mock_descend):
         pyclean.cli.main()
 
     assert mock_descend.mock_calls == [
-        call(Path('foo')),
-        call(Path('bar')),
-        call(Path('baz')),
+        call(Path('foo'), ['.pyc', '.pyo'], ['__pycache__']),
+        call(Path('bar'), ['.pyc', '.pyo'], ['__pycache__']),
+        call(Path('baz'), ['.pyc', '.pyo'], ['__pycache__']),
     ]
 
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="requires Python 3")
 @patch.object(pyclean.modern.logging, 'basicConfig')
-@patch('pyclean.modern.descend_and_clean_bytecode')
+@patch('pyclean.modern.descend_and_clean')
 def test_normal_logging(mock_descend, mock_logconfig):
     """
     Does a normal run use log level INFO?
@@ -65,7 +65,7 @@ def test_normal_logging(mock_descend, mock_logconfig):
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="requires Python 3")
 @patch.object(pyclean.modern.logging, 'basicConfig')
-@patch('pyclean.modern.descend_and_clean_bytecode')
+@patch('pyclean.modern.descend_and_clean')
 def test_verbose_logging(mock_descend, mock_logconfig):
     """
     Does --verbose use log level DEBUG?
@@ -80,7 +80,7 @@ def test_verbose_logging(mock_descend, mock_logconfig):
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="requires Python 3")
 @patch.object(pyclean.modern.logging, 'basicConfig')
-@patch('pyclean.modern.descend_and_clean_bytecode')
+@patch('pyclean.modern.descend_and_clean')
 def test_quiet_logging(mock_descend, mock_logconfig):
     """
     Does --quiet use log level FATAL?

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     flake8
     isort
     pylint
-    py{27,35,36,37,38,39,310,py2,py3}
+    py{27,35,36,37,38,39,310,311,py2,py3}
     bandit
     readme
     clean
@@ -20,6 +20,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
     pypy-2.7: pypy2
     pypy-3.7: pypy3
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands = bandit {posargs:-c pyproject.toml -r .}
 description = Ensure consistent code style
 skip_install = true
 deps = black
-commands = black --check --diff {posargs:pyclean setup.py tests}
+commands = black {posargs:--check --diff pyclean setup.py tests}
 
 [testenv:clean]
 description = Clean up bytecode and build artifacts
@@ -54,7 +54,7 @@ skip_install = true
 deps = pyclean
 commands =
     pyclean {posargs:.}
-    rm -rf .coverage .tox/ build/ dist/ pyclean.egg-info/ .pytest_cache/ pytestdebug.log tests/coverage-report.xml tests/unittests-report.xml
+    rm -rf .tox/ build/ .coverage coverage.xml dist/ pyclean.egg-info/ .pytest_cache/ pytestdebug.log tests/junit-report.xml
 allowlist_externals =
     rm
 
@@ -68,7 +68,7 @@ commands = flake8 {posargs}
 description = Ensure imports are ordered consistently
 skip_install = true
 deps = isort[colors]
-commands = isort --check-only --diff {posargs:pyclean tests setup.py}
+commands = isort {posargs:--check-only --diff pyclean tests setup.py}
 
 [testenv:pylint]
 description = Check for errors and code smells
@@ -93,6 +93,7 @@ commands =
 
 [flake8]
 exclude = .tox,build,dist,pyclean.egg-info
+max-line-length = 88
 per-file-ignores =
     pyclean/py2clean.py:E402
     pyclean/py3clean.py:E402
@@ -104,5 +105,5 @@ addopts =
     --ignore=pyclean/py2clean.py
     --ignore=pyclean/py3clean.py
     --ignore=pyclean/pypyclean.py
-    --junitxml=tests/unittests-report.xml
+    --junitxml=tests/junit-report.xml
     --verbose


### PR DESCRIPTION
Adds an option to clean up build artifacts other than Python bytecode, e.g.

- temporary files and folders from Python packaging
- test coverage data
- Pytest cache files and folders
- the Tox folder
- etc.