### PR TITLE
Allow to specify `--debris=all` to pick all topics

### DIFF
--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -16,6 +16,7 @@ def parse_arguments():
     """
     debris_default_topics = ['build', 'cache', 'coverage', 'pytest']
     debris_optional_topics = ['tox']
+    debris_choices = ['all'] + debris_default_topics + debris_optional_topics
     ignore_default_items = ['.git', '.hg', '.svn', '.tox', '.venv', 'node_modules']
 
     parser = argparse.ArgumentParser(
@@ -40,8 +41,7 @@ def parse_arguments():
                              '(may be specified multiple times; '
                              'default: %s)' % ' '.join(ignore_default_items))
     parser.add_argument('-d', '--debris', metavar='TOPIC', action='extend',
-                        nargs='*', default=argparse.SUPPRESS,
-                        choices=debris_default_topics + debris_optional_topics,
+                        nargs='*', default=argparse.SUPPRESS, choices=debris_choices,
                         help='remove leftovers from popular Python development '
                              'tools (may be specified multiple times; '
                              'default: %s)' % ' '.join(debris_default_topics))
@@ -64,9 +64,11 @@ def parse_arguments():
                      'must be specified.')
 
     if 'debris' in args:
-        if args.debris == []:
+        if 'all' in args.debris:
+            args.debris = debris_default_topics + debris_optional_topics
+        elif not args.debris:
             args.debris = debris_default_topics
-        log.debug("Debris requested to clean up for: %s", ' '.join(args.debris))
+        log.debug("Debris topics to scan for: %s", ' '.join(args.debris))
     else:
         args.debris = []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -133,6 +133,16 @@ def test_debris_default_args():
     assert args.debris == ['build', 'cache', 'coverage', 'pytest']
 
 
+def test_debris_all():
+    """
+    Does calling `pyclean --debris all` pick all topics?
+    """
+    with ArgvContext('pyclean', 'foo', '--debris', 'all'):
+        args = pyclean.cli.parse_arguments()
+
+    assert args.debris == ['build', 'cache', 'coverage', 'pytest', 'tox']
+
+
 def test_debris_explicit_args():
     """
     Does calling `pyclean --debris` with explicit arguments provide those?

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands = black {posargs:--check --diff pyclean setup.py tests}
 description = Clean up bytecode and build artifacts
 skip_install = true
 deps = pyclean
-commands = pyclean {posargs:.} --debris
+commands = pyclean {posargs:. --debris=all}
 
 [testenv:flake8]
 description = Static code analysis and code style


### PR DESCRIPTION
Adds a convenience value to pick all debris cleanup topics.