### PR TITLE
Add jupyter debris topic (clean up notebook checkpoints)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,8 @@ Python bytecode. The following topics are currently covered:
 - Coverage (coverage database, and supported file formats)
 - Packaging (build files and folders)
 - Pytest (build files and folders)
-- Tox (folder hosting Tox environments)
+- Jupyter (notebook checkpoints) – *optional*
+- Tox (tox environments) – *optional*
 
 *Example:* Dry-run a cleanup of bytecode and tool debris in verbose mode
 (to see what would be deleted):

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -15,7 +15,7 @@ def parse_arguments():
     Parse and handle CLI arguments
     """
     debris_default_topics = ['build', 'cache', 'coverage', 'pytest']
-    debris_optional_topics = ['tox']
+    debris_optional_topics = ['jupyter', 'tox']
     debris_choices = ['all'] + debris_default_topics + debris_optional_topics
     ignore_default_items = ['.git', '.hg', '.svn', '.tox', '.venv', 'node_modules']
 

--- a/pyclean/modern.py
+++ b/pyclean/modern.py
@@ -32,6 +32,10 @@ DEBRIS_TOPICS = {
         'htmlcov/**/*',
         'htmlcov/',
     ],
+    'jupyter': [
+        '.ipynb_checkpoints/**/*',
+        '.ipynb_checkpoints/',
+    ],
     'pytest': [
         '.pytest_cache/**/*',
         '.pytest_cache/',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,7 +140,7 @@ def test_debris_all():
     with ArgvContext('pyclean', 'foo', '--debris', 'all'):
         args = pyclean.cli.parse_arguments()
 
-    assert args.debris == ['build', 'cache', 'coverage', 'pytest', 'tox']
+    assert args.debris == ['build', 'cache', 'coverage', 'pytest', 'jupyter', 'tox']
 
 
 def test_debris_explicit_args():


### PR DESCRIPTION
The notebook checkpoint cleanup is implemented as an optional debris topic, which means that it must be explicitly requested via `-d jupyter` or `-d all`. The default (empty) `--debris` option will not trigger its cleanup.

Fixes #49