### PR TITLE
Allow deletion of free-form targets via `--erase`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,31 @@ Python bytecode. The following topics are currently covered:
 
     $ pyclean . --debris --verbose --dry-run
 
+Remove arbitrary file system objects
+------------------------------------
+
+PyClean also lets you remove free-form targets using globbing. Note that
+this is **potentially dangerous**: You can delete everything anywhere in
+the file system, including the entire project you're working on. For this
+reason, the `--erase` option has a few artificial constraints:
+
+- It doesn't do recursive deletion by itself, which means that you have
+  to specify the directory and its contents, separately and explicitly.
+- The above entails that you're responsible for the deletion order, i.e.
+  removal of a directory will only work if you asked to delete all files
+  inside first.
+- You're prompted interactively to confirm deletion, unless you add the
+  `--yes` option, in addition.
+
+.. code:: console
+
+    $ pyclean . --erase tmp/**/* tmp/
+
+The above would delete the entire ``tmp/`` directory with all subdirectories
+inside the current folder. If you omit the final ``tmp/`` you'll leave the
+empty ``tmp`` directory in place. (**WARNING!** Don't put the ``.`` *after*
+the ``--erase`` option! Obviously, your project files will all be deleted.)
+
 Use pyclean with Tox
 --------------------
 

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -46,7 +46,7 @@ def parse_arguments():
                              'tools (may be specified multiple times; '
                              'default: %s)' % ' '.join(debris_default_topics))
     parser.add_argument('-e', '--erase', metavar='PATTERN', action='extend',
-                        nargs='+',
+                        nargs='+', default=[],
                         help='delete files or folders matching a globbing '
                              'pattern (may be specified multiple times); '
                              'this will be interactive unless --yes is used.')

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -45,6 +45,11 @@ def parse_arguments():
                         help='remove leftovers from popular Python development '
                              'tools (may be specified multiple times; '
                              'default: %s)' % ' '.join(debris_default_topics))
+    parser.add_argument('-e', '--erase', metavar='PATTERN', action='extend',
+                        nargs='+',
+                        help='delete files or folders matching a globbing '
+                             'pattern (may be specified multiple times); '
+                             'this will be interactive unless --yes is used.')
     parser.add_argument('--legacy', action='store_true',
                         help='use legacy Debian implementation (autodetect)')
     parser.add_argument('-n', '--dry-run', action='store_true',
@@ -56,8 +61,14 @@ def parse_arguments():
     verbosity.add_argument('-v', '--verbose', action='store_true',
                            help='be more verbose')
 
+    parser.add_argument('-y', '--yes', action='store_true',
+                        help='assume yes as answer for interactive questions')
+
     args = parser.parse_args()
     init_logging(args)
+
+    if args.yes and not args.erase:
+        parser.error('Specifying --yes only makes sense with --erase.')
 
     if not (args.package or args.directory):
         parser.error('A directory (or files) or a list of packages '

--- a/pyclean/modern.py
+++ b/pyclean/modern.py
@@ -58,6 +58,13 @@ class Runner:  # pylint: disable=too-few-public-methods
     unlink_failed = 0
 
 
+def initialize_runner(args):
+    """Sets up the Runner class with static attributes."""
+    Runner.unlink = print_filename if args.dry_run else remove_file
+    Runner.rmdir = print_dirname if args.dry_run else remove_directory
+    Runner.ignore = args.ignore
+
+
 def remove_file(fileobj):
     """Attempt to delete a file object for real."""
     log.debug("Deleting file: %s", fileobj)
@@ -94,9 +101,7 @@ def print_dirname(dirobj):
 
 def pyclean(args):
     """Cross-platform cleaning of Python bytecode."""
-    Runner.unlink = print_filename if args.dry_run else remove_file
-    Runner.rmdir = print_dirname if args.dry_run else remove_directory
-    Runner.ignore = args.ignore
+    initialize_runner(args)
 
     for dir_name in args.directory:
         directory = Path(dir_name)

--- a/pyclean/modern.py
+++ b/pyclean/modern.py
@@ -104,15 +104,15 @@ def pyclean(args):
     initialize_runner(args)
 
     for dir_name in args.directory:
-        directory = Path(dir_name)
+        dir_path = Path(dir_name)
 
-        log.info("Cleaning directory %s", directory)
-        descend_and_clean(directory, BYTECODE_FILES, BYTECODE_DIRS)
+        log.info("Cleaning directory %s", dir_path)
+        descend_and_clean(dir_path, BYTECODE_FILES, BYTECODE_DIRS)
 
-    for topic in args.debris:
-        remove_debris_for(topic, args.directory)
+        for topic in args.debris:
+            remove_debris_for(topic, dir_path)
 
-    remove_freeform_targets(args.erase, args.yes, args.directory)
+        remove_freeform_targets(args.erase, args.yes, dir_path)
 
     log.info("Total %d files, %d directories %s.",
              Runner.unlink_count, Runner.rmdir_count,

--- a/tests/py3_mocks.py
+++ b/tests/py3_mocks.py
@@ -1,0 +1,59 @@
+"""
+Mock objects for tests of the modern implementation.
+"""
+try:
+    from pathlib import Path
+    from unittest.mock import Mock
+except ImportError:  # Python 2.7, PyPy2
+    import pytest
+    pytest.importorskip("pathlib")
+
+
+class FilesystemObjectMock(Mock):
+
+    def __init__(self, *args, **kwargs):
+        name = kwargs['name'] if 'name' in kwargs else args[0]
+        super().__init__(autospec=Path(name), **kwargs)
+        self.name = name
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+    def __lt__(self, other):
+        return self.name < other.name
+
+    def is_file(self):
+        return False
+
+    def is_dir(self):
+        return False
+
+    def is_symlink(self):
+        return False
+
+
+class DirectoryMock(FilesystemObjectMock):
+
+    def __init__(self, **kwargs):
+        super().__init__('a-dir', **kwargs)
+
+    def is_dir(self):
+        return True
+
+
+class FileMock(FilesystemObjectMock):
+
+    def __init__(self, **kwargs):
+        super().__init__('a-file', **kwargs)
+
+    def is_file(self):
+        return True
+
+
+class SymlinkMock(FilesystemObjectMock):
+
+    def __init__(self, **kwargs):
+        super().__init__('a-symlink', **kwargs)
+
+    def is_symlink(self):
+        return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -188,6 +188,54 @@ def test_debris_invalid_args():
         pyclean.cli.parse_arguments()
 
 
+@pytest.mark.parametrize(
+    'cli_args,erase_result',
+    [
+        (['--erase', 'foo'], ['foo']),
+        (['--erase', 'a', 'b', 'c'], ['a', 'b', 'c']),
+        (['--erase=tmp/*', '--erase=tmp'], ['tmp/*', 'tmp']),
+        (['-e', 'x', '-e', 'y', 'z'], ['x', 'y', 'z']),
+    ]
+)
+def test_erase_multiple_args(cli_args, erase_result):
+    """
+    Does `--erase` accept multiple arguments, in different styles?
+    """
+    with ArgvContext('pyclean', '.', *cli_args):
+        args = pyclean.cli.parse_arguments()
+
+    assert args.erase == erase_result
+    assert not args.yes
+
+
+def test_erase_alone_aborts():
+    """
+    Does CLI abort when using `--erase` option without arguments?
+    """
+    with ArgvContext('pyclean', '.', '--erase'), pytest.raises(SystemExit):
+        pyclean.cli.parse_arguments()
+
+
+@pytest.mark.parametrize('option', ['--yes', '-y'])
+def test_yes_option(option):
+    """
+    Is `--yes` option available, in long and short form?
+    """
+    with ArgvContext('pyclean', '.', '-e', 'tmp', option):
+        args = pyclean.cli.parse_arguments()
+
+    assert args.yes
+    assert args.erase == ['tmp']
+
+
+def test_yes_aborts_without_erase():
+    """
+    Does CLI abort when `--yes` is specified without `--erase`?
+    """
+    with ArgvContext('pyclean', '.', '--yes'), pytest.raises(SystemExit):
+        pyclean.cli.parse_arguments()
+
+
 def test_version_option():
     """
     Does --version yield the expected information?

--- a/tests/test_modern.py
+++ b/tests/test_modern.py
@@ -11,9 +11,10 @@ try:
     from pathlib import Path
     from unittest.mock import Mock, call, patch
 except ImportError:  # Python 2.7, PyPy2
-    from mock import patch
+    pytest.importorskip("pathlib")
 
 from cli_test_helpers import ArgvContext
+from py3_mocks import DirectoryMock, FileMock, SymlinkMock
 
 import pyclean.cli
 import pyclean.modern
@@ -23,56 +24,6 @@ from pyclean.modern import (
     remove_debris_for,
     remove_freeform_targets,
 )
-
-
-class FilesystemObjectMock(Mock):
-
-    def __init__(self, *args, **kwargs):
-        name = kwargs['name'] if 'name' in kwargs else args[0]
-        super().__init__(autospec=Path(name), **kwargs)
-        self.name = name
-
-    def __eq__(self, other):
-        return self.name == other.name
-
-    def __lt__(self, other):
-        return self.name < other.name
-
-    def is_file(self):
-        return False
-
-    def is_dir(self):
-        return False
-
-    def is_symlink(self):
-        return False
-
-
-class DirectoryMock(FilesystemObjectMock):
-
-    def __init__(self, **kwargs):
-        super().__init__('a-dir', **kwargs)
-
-    def is_dir(self):
-        return True
-
-
-class FileMock(FilesystemObjectMock):
-
-    def __init__(self, **kwargs):
-        super().__init__('a-file', **kwargs)
-
-    def is_file(self):
-        return True
-
-
-class SymlinkMock(FilesystemObjectMock):
-
-    def __init__(self, **kwargs):
-        super().__init__('a-symlink', **kwargs)
-
-    def is_symlink(self):
-        return True
 
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="requires Python 3")


### PR DESCRIPTION
The new `--erase` option allows you to delete any file using a glob syntax inside the directories you specify.