### PR TITLE
Rename debris topic build ➜ package

### DIFF
--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -14,7 +14,7 @@ def parse_arguments():
     """
     Parse and handle CLI arguments
     """
-    debris_default_topics = ['build', 'cache', 'coverage', 'pytest']
+    debris_default_topics = ['cache', 'coverage', 'package', 'pytest']
     debris_optional_topics = ['jupyter', 'tox']
     debris_choices = ['all'] + debris_default_topics + debris_optional_topics
     ignore_default_items = ['.git', '.hg', '.svn', '.tox', '.venv', 'node_modules']

--- a/pyclean/modern.py
+++ b/pyclean/modern.py
@@ -12,7 +12,7 @@ except ImportError:  # Python 2.7, PyPy2
 BYTECODE_FILES = ['.pyc', '.pyo']
 BYTECODE_DIRS = ['__pycache__']
 DEBRIS_TOPICS = {
-    'build': [
+    'package': [
         'dist/**/*',
         'dist/',
         'sdist/**/*',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,7 +156,7 @@ def test_debris_default_args():
     with ArgvContext('pyclean', 'foo', '--debris'):
         args = pyclean.cli.parse_arguments()
 
-    assert args.debris == ['build', 'cache', 'coverage', 'pytest']
+    assert args.debris == ['cache', 'coverage', 'package', 'pytest']
 
 
 def test_debris_all():
@@ -166,17 +166,17 @@ def test_debris_all():
     with ArgvContext('pyclean', 'foo', '--debris', 'all'):
         args = pyclean.cli.parse_arguments()
 
-    assert args.debris == ['build', 'cache', 'coverage', 'pytest', 'jupyter', 'tox']
+    assert args.debris == ['cache', 'coverage', 'package', 'pytest', 'jupyter', 'tox']
 
 
 def test_debris_explicit_args():
     """
     Does calling `pyclean --debris` with explicit arguments provide those?
     """
-    with ArgvContext('pyclean', 'foo', '--debris', 'build', 'pytest'):
+    with ArgvContext('pyclean', 'foo', '--debris', 'package', 'pytest'):
         args = pyclean.cli.parse_arguments()
 
-    assert args.debris == ['build', 'pytest']
+    assert args.debris == ['package', 'pytest']
 
 
 def test_debris_invalid_args():

--- a/tests/test_modern.py
+++ b/tests/test_modern.py
@@ -242,8 +242,8 @@ def test_dryrun(
     'options,scanned_topics',
     [
         ([], []),
-        (['-d'], ['build', 'cache', 'coverage', 'pytest']),
-        (['-d', 'build', 'coverage'], ['build', 'coverage']),
+        (['-d'], ['cache', 'coverage', 'package', 'pytest']),
+        (['-d', 'coverage', 'package'], ['coverage', 'package']),
     ]
 )
 @patch('pyclean.modern.remove_freeform_targets')


### PR DESCRIPTION
While "package" is very specific to Python packaging, "build" is too generic and can be (better) used for other debris collections.