### PR TITLE
Give the readme CI job a more generic name

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
         - isort
         - pylint
         - bandit
-        - readme
+        - package
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist =
     py3{5,6,7,8,9,10,11}
     pypy{2,3}
     bandit
-    readme
+    package
     clean
 
 [gh-actions]
@@ -69,26 +69,30 @@ skip_install = true
 deps = isort[colors]
 commands = isort {posargs:--check-only --diff pyclean tests setup.py}
 
-[testenv:pylint]
-description = Check for errors and code smells
-deps = pylint
-commands = pylint {posargs:pyclean setup}
-
 [testenv:license]
 description = Manage license compliance
 skip_install = true
 deps = reuse
 commands = reuse {posargs:lint}
 
-[testenv:readme]
-description = Ensure README renders on PyPI
+[testenv:package]
+description = Build package and check metadata (or upload package)
 skip_install = true
 deps =
     build
     twine
 commands =
     python -m build
-    twine check dist/*
+    twine {posargs:check --strict} dist/*
+passenv =
+    TWINE_USERNAME
+    TWINE_PASSWORD
+    TWINE_REPOSITORY_URL
+
+[testenv:pylint]
+description = Check for errors and code smells
+deps = pylint
+commands = pylint {posargs:pyclean setup}
 
 [flake8]
 exclude = .tox,build,dist,pyclean.egg-info


### PR DESCRIPTION
The `readme` job that was originally introduced to safeguard against READMEs on PyPI not being rendered (due to reST-to-HTML conversion errors) has evolved to a generic packaging check. The job name should reflect this fact.