### PR TITLE
Count/report not-deleted objects correctly w/ `--erase`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         - '3.10'
         - '3.11'
         - pypy-2.7
-        - pypy-3.7
+        - pypy-3.8
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/pyclean/__init__.py
+++ b/pyclean/__init__.py
@@ -2,4 +2,4 @@
 Pure Python cross-platform pyclean. Clean up your Python bytecode.
 """
 
-__version__ = '2.7.1'
+__version__ = '2.7.2'

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ python =
     3.10: py310
     3.11: py311
     pypy-2.7: pypy2
-    pypy-3.7: pypy3
+    pypy-3.8: pypy3
 
 [testenv]
 description = Unit tests and test coverage


### PR DESCRIPTION
When interactive confirmation is denied we also want the user to get those objects counted as not deleted. Similarly, we want to use more appropriate wording when performing dry-runs.