### PR TITLE
Use Tox default environment names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,11 @@ Run the linters and our test suite using Tox, e.g.
 
 ```console
 # show all Tox targets
-tox -lv
+tox list
 ```
 ```console
 # run just flake8 and the test for Python 3.7
-tox -e flake8,py37
+tox -e flake8,3.7
 ```
 ```console
 # run entire test suite

--- a/tox.ini
+++ b/tox.ini
@@ -6,38 +6,33 @@ envlist =
     flake8
     isort
     pylint
-    py2{7}
-    py3{5,6,7,8,9,10,11}
-    pypy{2,3}
+    2.{7}
+    3.{5,6,7,8,9,10,11}
+    pypy-{2,3.8}
     bandit
     package
     clean
-
-[gh-actions]
-python =
-    2.7: py27
-    3.5: py35
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    pypy-2.7: pypy2
-    pypy-3.8: pypy3
 
 [testenv]
 description = Unit tests and test coverage
 deps =
     cli-test-helpers
-    py27: mock
-    pypy2: mock
+    2.7: mock
+    pypy-2: mock
     coverage[toml]
     pytest
 commands =
     coverage run -m pytest {posargs}
     coverage xml
     coverage report
+
+[gh-actions]
+fail_on_no_env = True
+python =
+    2.7: 2.7
+    3.5: 3.5
+    3.6: 3.6
+    pypy-2: pypy-2
 
 [testenv:bandit]
 description = PyCQA security linter


### PR DESCRIPTION
The `tox list` command displays environments that are not explicitly mentioned in the `envlist` section of the `tox.ini` file as "additional environments".

In Tox v3 they used to be called, `py27`, `py37`, etc. but in Tox v4 they have now become simply the Python version specifiers.

## Backwards-compatibility

Note that only for Tox v3, which still supports Python < 3.7, we need to populate the `[gh-actions]` section with a version identifier mapping. Once only Python 3.7+ is supported the `python` version mapping can be removed.

## Example

```console
$ tox list
default environments:
flake8   -> Static code analysis and code style
isort    -> Ensure imports are ordered consistently
pylint   -> Check for errors and code smells
2.7      -> Unit tests and test coverage
3.5      -> Unit tests and test coverage
3.6      -> Unit tests and test coverage
3.7      -> Unit tests and test coverage
3.8      -> Unit tests and test coverage
3.9      -> Unit tests and test coverage
3.10     -> Unit tests and test coverage
3.11     -> Unit tests and test coverage
pypy-2   -> Unit tests and test coverage
pypy-3.8 -> Unit tests and test coverage
bandit   -> PyCQA security linter
package  -> Build package and check metadata (or upload package)
clean    -> Clean up bytecode and build artifacts

additional environments:
black    -> Ensure consistent code style
license  -> Manage license compliance
```