### PR TITLE
Add mypy as an optional debris topic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,7 @@ Python bytecode. The following topics are currently covered:
 - Packaging (build files and folders)
 - Pytest (build files and folders)
 - Jupyter (notebook checkpoints) – *optional*
+- Mypy (mypy cache folder) – *optional*
 - Tox (tox environments) – *optional*
 
 *Example:* Dry-run a cleanup of bytecode and tool debris in verbose mode

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -15,7 +15,7 @@ def parse_arguments():
     Parse and handle CLI arguments
     """
     debris_default_topics = ['cache', 'coverage', 'package', 'pytest']
-    debris_optional_topics = ['jupyter', 'tox']
+    debris_optional_topics = ['jupyter', 'mypy', 'tox']
     debris_choices = ['all'] + debris_default_topics + debris_optional_topics
     ignore_default_items = ['.git', '.hg', '.svn', '.tox', '.venv', 'node_modules']
 

--- a/pyclean/modern.py
+++ b/pyclean/modern.py
@@ -28,6 +28,10 @@ DEBRIS_TOPICS = {
         '.ipynb_checkpoints/**/*',
         '.ipynb_checkpoints/',
     ],
+    'mypy': [
+        '.mypy_cache/**/*',
+        '.mypy_cache/',
+    ],
     'package': [
         'build/bdist.*/**/*',
         'build/bdist.*/',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,7 +166,15 @@ def test_debris_all():
     with ArgvContext('pyclean', 'foo', '--debris', 'all'):
         args = pyclean.cli.parse_arguments()
 
-    assert args.debris == ['cache', 'coverage', 'package', 'pytest', 'jupyter', 'tox']
+    assert args.debris == [
+        'cache',
+        'coverage',
+        'package',
+        'pytest',
+        'jupyter',
+        'mypy',
+        'tox',
+    ]
 
 
 def test_debris_explicit_args():

--- a/tests/test_modern.py
+++ b/tests/test_modern.py
@@ -252,6 +252,7 @@ def test_dryrun(
         ([], []),
         (['-d'], ['cache', 'coverage', 'package', 'pytest']),
         (['-d', 'coverage', 'package'], ['coverage', 'package']),
+        (['-d', 'jupyter', 'mypy', 'tox'], ['jupyter', 'mypy', 'tox']),
     ]
 )
 @patch('pyclean.modern.remove_freeform_targets')
@@ -288,19 +289,30 @@ def test_erase_option(mock_descend, mock_debris, mock_erase):
     assert erase_calls == [['tmp/**/*', 'tmp/']]
 
 
+@pytest.mark.parametrize(
+    'debris_topic',
+    [
+        'cache',
+        'coverage',
+        'package',
+        'pytest',
+        'jupyter',
+        'mypy',
+        'tox',
+    ]
+)
 @patch('pyclean.modern.delete_filesystem_objects')
-def test_debris_loop(mock_delete_fs_obj):
+def test_debris_loop(mock_delete_fs_obj, debris_topic):
     """
     Does ``remove_debris_for()`` call filesystem object removal?
     """
-    pyclean.modern.DEBRIS_TOPICS = {'foo': ['somedir/']}
+    fileobject_globs = pyclean.modern.DEBRIS_TOPICS[debris_topic]
     directory = Path('.')
+    expected_calls = [call(directory, pattern) for pattern in fileobject_globs]
 
-    remove_debris_for('foo', directory)
+    remove_debris_for(debris_topic, directory)
 
-    assert mock_delete_fs_obj.call_args_list == [
-        call(directory, 'somedir/'),
-    ]
+    assert mock_delete_fs_obj.call_args_list == expected_calls
 
 
 @patch('pyclean.modern.delete_filesystem_objects')


### PR DESCRIPTION
Mypy creates a [`.mypy_cache`](https://mypy.readthedocs.io/en/stable/config_file.html#incremental-mode) folder, which developers may want to remove.