### PR TITLE
Fix additional environments shown by `tox list`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install build tools
       run: |
-        python -m pip install tox-gh-actions wheel
+        python -m pip install tox-gh wheel
     - name: Run tests
       run: tox
     - name: Upload coverage report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
         - '3.11'
         - pypy-2.7
         - pypy-3.8
+        - pypy-3.9
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install build tools
       run: |
-        python -m pip install tox-gh wheel
+        python -m pip install tox-gh-actions wheel
     - name: Run tests
       run: tox
     - name: Upload coverage report

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,12 @@ tox list
 
 ```console
 # run just flake8 and the tests for Python 3.10
-tox -e flake8,3.10
+tox -e flake8,py310
+```
+
+```console
+# run tests with your default Python (the one executing Tox)
+tox -e py
 ```
 
 ```console

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@ envlist =
     flake8
     isort
     pylint
-    2.{7}
-    3.{5,6,7,8,9,10,11}
-    pypy-{2,3.8}
+    py2{7}
+    py3{5,6,7,8,9,10,11}
+    pypy{2,3}
     bandit
     package
     clean
@@ -16,17 +16,23 @@ envlist =
 [gh-actions]
 fail_on_no_env = True
 python =
-    2.7: 2.7
-    3.5: 3.5
-    3.6: 3.6
-    pypy-2: pypy-2
+    2.7: py27
+    3.5: py35
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    pypy-2.7: pypy2
+    pypy-3.8: pypy3
 
 [testenv]
 description = Unit tests and test coverage
 deps =
     cli-test-helpers
-    2.7: mock
-    pypy-2: mock
+    py27: mock
+    pypy2: mock
     coverage[toml]
     pytest
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -13,19 +13,18 @@ envlist =
     package
     clean
 
-[gh-actions]
-fail_on_no_env = True
+[gh]
 python =
-    2.7: py27
-    3.5: py35
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    pypy-2.7: pypy2
-    pypy-3.8: pypy3
+    2.7 = py27
+    3.5 = py35
+    3.6 = py36
+    3.7 = py37
+    3.8 = py38
+    3.9 = py39
+    3.10 = py310
+    3.11 = py311
+    pypy-2.7 = pypy2
+    pypy-3.8 = pypy3
 
 [testenv]
 description = Unit tests and test coverage

--- a/tox.ini
+++ b/tox.ini
@@ -14,26 +14,26 @@ envlist =
     package
     clean
 
-[gh]
+[gh-actions]
 python =
-    2.7 = py27
-    3.5 = py35
-    3.6 = py36
-    3.7 = py37
-    3.8 = py38
-    3.9 = py39
-    3.10 = py310
-    3.11 = py311
-    pypy-2.7 = pypy27
-    pypy-3.8 = pypy38
-    pypy-3.9 = pypy39
+    2.7: py27
+    3.5: py35
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    pypy-2.7: pypy27
+    pypy-3.8: pypy38
+    pypy-3.9: pypy39
 
 [testenv]
 description = Unit tests and test coverage
 deps =
     cli-test-helpers
     py27: mock
-    pypy2: mock
+    pypy27: mock
     coverage[toml]
     pytest
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,9 @@ envlist =
     isort
     pylint
     py2{7}
+    pypy2{7}
     py3{5,6,7,8,9,10,11}
-    pypy{2,3}
+    pypy3{8,9}
     bandit
     package
     clean
@@ -23,8 +24,9 @@ python =
     3.9 = py39
     3.10 = py310
     3.11 = py311
-    pypy-2.7 = pypy2
-    pypy-3.8 = pypy3
+    pypy-2.7 = pypy27
+    pypy-3.8 = pypy38
+    pypy-3.9 = pypy39
 
 [testenv]
 description = Unit tests and test coverage


### PR DESCRIPTION
In commit 5fcdc928d622e13226cf0c94200630f6c1426fa7 we made the irritating "additional environments" go away that were shown by the `tox list` command. Unfortunately, the solution broke the automatic selection of the appropriate Python interpreter version. The reason for this is [outlined in the Tox docs](https://tox.wiki/en/latest/user_guide.html#test-environments):

> tox, by default, always creates a fresh virtual environment for every run environment. The Python version to use for a given environment can be controlled via the [base_python](https://tox.wiki/en/latest/config.html#base_python) configuration, however if not set will try to use the environment name to determine something sensible: if the name is in the format of `pyxy` then tox will create an environment with CPython with version `x.y` (for example `py310` means CPython `3.10`). **If the name does not match this pattern it will use a virtual environment with the same Python version as the one tox is installed into** (this is the case for `format`).

The setup ran correctly on GHA only because the specified Python versions we the only ones available, as [provisioned by the GHA pipeline setup](https://github.com/bittner/pyclean/blob/main/.github/workflows/test.yml#L25-L45).

## See also

- https://github.com/tox-dev/tox/discussions/3014