### PR TITLE
Continue to run older Pythons with Tox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,31 +19,27 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - ubuntu-20.04
+        - ubuntu-latest
         - macos-latest
         - windows-latest
         python-version:
-        - '2.7'
-        - '3.5'
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
-        - pypy-2.7
         - pypy-3.8
         - pypy-3.9
+        - pypy-3.10
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install build tools
-      run: |
-        python -m pip install tox-gh-actions wheel
+      run: python -m pip install tox wheel
     - name: Run tests
-      run: tox
+      run: tox run -e py
     - name: Upload coverage report
       uses: codacy/codacy-coverage-reporter-action@v1
       with:

--- a/tox.ini
+++ b/tox.ini
@@ -9,25 +9,11 @@ envlist =
     py2{7}
     pypy2{7}
     py3{5,6,7,8,9,10,11}
-    pypy3{8,9}
+    pypy3{8,9,10}
     bandit
     package
     clean
 requires = virtualenv<20.22.0
-
-[gh-actions]
-python =
-    2.7: py27
-    3.5: py35
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    pypy-2.7: pypy27
-    pypy-3.8: pypy38
-    pypy-3.9: pypy39
 
 [testenv]
 description = Unit tests and test coverage

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist =
     bandit
     package
     clean
+requires = virtualenv<20.22.0
 
 [gh-actions]
 python =


### PR DESCRIPTION
Virtualenv 20.22.0 dropped support for all Python versions < 3.7

Other than that, the [GitHub hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software) have started to consequently remove older Python versions. The Ubuntu 20.04 VM image used to still ship Python 2.7 and 3.5 upwards, but supporting those Python versions seems to have been discontinued, finally.

Nonetheless, we'll keep the (Tox) test setup running for older Python locally. The burden to verify that older Pythons are still supported remains on the developer, from now on.

## See also

- [Tox docs](https://tox.wiki/en/latest/faq.html#testing-end-of-life-python-versions) - _Testing end-of-life Python versions_
- [GitHub hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software) - _Supported software_