### PR TITLE
Use ruff as the one linter for everything

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,10 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
-        - flake8
-        - isort
-        - pylint
-        - bandit
+        - ruff
         - package
     steps:
     - uses: actions/checkout@v3
@@ -33,4 +30,4 @@ jobs:
       run: |
         python -m pip install tox wheel
     - name: Run ${{ matrix.env }}
-      run: tox -e ${{ matrix.env }}
+      run: tox run -e ${{ matrix.env }}

--- a/README.rst
+++ b/README.rst
@@ -192,7 +192,7 @@ You'll then be able to run it with `Tox`_ like this:
 
     $ tox -e clean
 
-.. _Tox: https://tox.readthedocs.io/
+.. _Tox: https://tox.wiki/
 
 Development
 ===========

--- a/pyclean/compat.py
+++ b/pyclean/compat.py
@@ -21,7 +21,7 @@ def get_implementation(override=None):
 
     detected_version = '%s%s' % (
         platform.python_implementation(),
-        sys.version[0],
+        sys.version_info.major,
     )
 
     module_name = implementation[override if override else detected_version]

--- a/pyclean/modern.py
+++ b/pyclean/modern.py
@@ -232,4 +232,5 @@ def confirm(message):
         answer = input("%s? " % message)
         return answer.strip().lower() in ['y', 'yes']
     except KeyboardInterrupt:
-        raise SystemExit('Aborted by user.')
+        msg = 'Aborted by user.'
+        raise SystemExit(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,6 @@ pypyclean = "pyclean.cli:pypyclean"
 [project.urls]
 homepage = "https://github.com/bittner/pyclean"
 
-[tool.bandit]
-exclude_dirs = [".git",".github",".tox","tests","pyclean/py2clean.py","pyclean/py3clean.py","pyclean/pypyclean.py"]
-
 [tool.black]
 color = true
 
@@ -61,17 +58,20 @@ source = ["pyclean"]
 [tool.coverage.report]
 show_missing = true
 
-[tool.isort]
-color_output = true
-profile = "black"
-
-[tool.pylint.master]
-disable = ["consider-using-f-string","raise-missing-from","use-dict-literal"]
-ignore = ["py2clean.py","py3clean.py","pypyclean.py"]
-output-format = "colorized"
-
 [tool.pytest.ini_options]
 addopts = "--color=yes --doctest-modules --ignore=pyclean/py2clean.py --ignore=pyclean/py3clean.py --ignore=pyclean/pypyclean.py --junitxml=tests/junit-report.xml --verbose"
+
+[tool.ruff]
+extend-exclude = []
+extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N", "PIE", "PL", "PT", "PTH", "R", "S", "SIM", "T10", "TID", "W", "YTT"]
+extend-ignore = []
+
+[tool.ruff.per-file-ignores]
+"pyclean/compat.py" = ["C408"]
+"pyclean/py2clean.py" = ["E402", "PTH"]
+"pyclean/py3clean.py" = ["BLE001", "C901", "E402", "PLR1722", "PTH", "S110", "SIM105"]
+"pyclean/pypyclean.py" = ["B007", "G002", "PTH", "S603"]
+"tests/*.py" = ["S101"]
 
 [tool.setuptools]
 packages = ["pyclean"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ extend-ignore = []
 
 [tool.ruff.per-file-ignores]
 "pyclean/compat.py" = ["C408"]
+"pyclean/modern.py" = ["B028", "B904"]
 "pyclean/py2clean.py" = ["E402", "PTH"]
 "pyclean/py3clean.py" = ["BLE001", "C901", "E402", "PLR1722", "PTH", "S110", "SIM105"]
 "pyclean/pypyclean.py" = ["B007", "G002", "PTH", "S603"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,7 +112,14 @@ def test_mandatory_arg_missing(mock_getimpl, mock_modern):
     assert not mock_modern.called
 
 
-@pytest.mark.parametrize('options', (['.'], ['--package=foo'], ['.', '-p', 'foo']))
+@pytest.mark.parametrize(
+    'options',
+    [
+        ['.'],
+        ['--package=foo'],
+        ['.', '-p', 'foo'],
+    ],
+)
 @patch('pyclean.cli.modern.pyclean')
 @patch('pyclean.cli.compat.get_implementation')
 def test_mandatory_args(mock_getimpl, mock_modern, options):
@@ -196,13 +203,13 @@ def test_debris_invalid_args():
 
 
 @pytest.mark.parametrize(
-    'cli_args,erase_result',
+    ('cli_args', 'erase_result'),
     [
         (['--erase', 'foo'], ['foo']),
         (['--erase', 'a', 'b', 'c'], ['a', 'b', 'c']),
         (['--erase=tmp/*', '--erase=tmp'], ['tmp/*', 'tmp']),
         (['-e', 'x', '-e', 'y', 'z'], ['x', 'y', 'z']),
-    ]
+    ],
 )
 def test_erase_multiple_args(cli_args, erase_result):
     """

--- a/tests/test_modern.py
+++ b/tests/test_modern.py
@@ -35,7 +35,7 @@ def test_walks_tree(mock_descend):
         pyclean.cli.main()
 
     assert mock_descend.mock_calls == [
-        call(Path('.'), ['.pyc', '.pyo'], ['__pycache__']),
+        call(Path(), ['.pyc', '.pyo'], ['__pycache__']),
     ]
 
 
@@ -106,7 +106,7 @@ def test_ignore_otherobjects(mock_iterdir):
     pyclean.modern.log = Mock()
 
     pyclean.modern.descend_and_clean(
-        Path('.'), pyclean.modern.BYTECODE_FILES, pyclean.modern.BYTECODE_DIRS
+        Path(), pyclean.modern.BYTECODE_FILES, pyclean.modern.BYTECODE_DIRS,
     )
 
     assert not pyclean.modern.Runner.unlink.called
@@ -116,7 +116,14 @@ def test_ignore_otherobjects(mock_iterdir):
     ]
 
 
-@pytest.mark.parametrize('unlink_failures,rmdir_failures', [(7, 0), (0, 3), (1, 1)])
+@pytest.mark.parametrize(
+    ('unlink_failures', 'rmdir_failures'),
+    [
+        (7, 0),
+        (0, 3),
+        (1, 1),
+    ],
+)
 def test_report_failures(unlink_failures, rmdir_failures):
     """
     Are failures to delete a file or folder reported with ``log.debug``?
@@ -213,7 +220,7 @@ def test_dryrun_output(mock_log):
 @patch('pyclean.modern.remove_directory')
 @patch('pyclean.modern.remove_file')
 def test_delete(
-    mock_real_unlink, mock_real_rmdir, mock_dry_unlink, mock_dry_rmdir
+    mock_real_unlink, mock_real_rmdir, mock_dry_unlink, mock_dry_rmdir,
 ):
     """
     Is actual deletion attempted w/o --dry-run?
@@ -232,7 +239,7 @@ def test_delete(
 @patch('pyclean.modern.remove_directory')
 @patch('pyclean.modern.remove_file')
 def test_dryrun(
-    mock_real_unlink, mock_real_rmdir, mock_dry_unlink, mock_dry_rmdir
+    mock_real_unlink, mock_real_rmdir, mock_dry_unlink, mock_dry_rmdir,
 ):
     """
     Does --dry-run option avoid real deletion?
@@ -247,13 +254,13 @@ def test_dryrun(
 
 
 @pytest.mark.parametrize(
-    'options,scanned_topics',
+    ('options', 'scanned_topics'),
     [
         ([], []),
         (['-d'], ['cache', 'coverage', 'package', 'pytest']),
         (['-d', 'coverage', 'package'], ['coverage', 'package']),
         (['-d', 'jupyter', 'mypy', 'tox'], ['jupyter', 'mypy', 'tox']),
-    ]
+    ],
 )
 @patch('pyclean.modern.remove_freeform_targets')
 @patch('pyclean.modern.remove_debris_for')
@@ -299,7 +306,7 @@ def test_erase_option(mock_descend, mock_debris, mock_erase):
         'jupyter',
         'mypy',
         'tox',
-    ]
+    ],
 )
 @patch('pyclean.modern.delete_filesystem_objects')
 def test_debris_loop(mock_delete_fs_obj, debris_topic):
@@ -307,7 +314,7 @@ def test_debris_loop(mock_delete_fs_obj, debris_topic):
     Does ``remove_debris_for()`` call filesystem object removal?
     """
     fileobject_globs = pyclean.modern.DEBRIS_TOPICS[debris_topic]
-    directory = Path('.')
+    directory = Path()
     expected_calls = [call(directory, pattern) for pattern in fileobject_globs]
 
     remove_debris_for(debris_topic, directory)
@@ -321,7 +328,7 @@ def test_erase_loop(mock_delete_fs_obj):
     Does ``remove_freeform_targets()`` call filesystem object removal?
     """
     patterns = ['foo.txt']
-    directory = Path('.')
+    directory = Path()
 
     remove_freeform_targets(patterns, yes=False, directory=directory)
 
@@ -339,14 +346,14 @@ def test_erase_loop(mock_delete_fs_obj):
         DirectoryMock(),
         SymlinkMock(),
         FileMock(),
-    ]
+    ],
 )
 def test_delete_filesdir_loop(mock_glob, mock_yes, mock_unlink, mock_rmdir):
     """
     Exercise the file and directory loop code.
     """
     args = Namespace(dry_run=False, ignore=[])
-    directory = Path('.')
+    directory = Path()
 
     pyclean.modern.Runner.configure(args)
     delete_filesystem_objects(directory, 'tmp/**/*', prompt=True)
@@ -374,14 +381,14 @@ def test_delete_filesdir_loop(mock_glob, mock_yes, mock_unlink, mock_rmdir):
         DirectoryMock(),
         SymlinkMock(),
         FileMock(),
-    ]
+    ],
 )
 def test_no_skips_deletion(mock_glob, mock_no, mock_unlink, mock_rmdir):
     """
     Is deletion skipped with --erase when user says "no" at the prompt?
     """
     args = Namespace(dry_run=False, ignore=[])
-    directory = Path('.')
+    directory = Path()
 
     pyclean.modern.Runner.configure(args)
 
@@ -406,12 +413,12 @@ def test_no_skips_deletion(mock_glob, mock_no, mock_unlink, mock_rmdir):
         DirectoryMock(),
         SymlinkMock(),
         FileMock(),
-    ]
+    ],
 )
 @patch('pyclean.modern.remove_debris_for')
 @patch('pyclean.modern.descend_and_clean')
 def test_yes_skips_prompt(
-    mock_descend, mock_debris, mock_glob, mock_unlink, mock_rmdir
+    mock_descend, mock_debris, mock_glob, mock_unlink, mock_rmdir,
 ):
     """
     Does --yes skip the confirmation prompt for --erase?

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,12 @@
 # Tox (https://tox.wiki/) - run tests in isolation using virtualenv.
-# Also contains config settings for tools that don't look into pyproject.toml.
 
 [tox]
 envlist =
-    flake8
-    isort
-    pylint
+    ruff
     py2{7}
     pypy2{7}
     py3{5,6,7,8,9,10,11}
     pypy3{8,9,10}
-    bandit
     package
     clean
 requires = virtualenv<20.22.0
@@ -28,12 +24,6 @@ commands =
     coverage xml
     coverage report
 
-[testenv:bandit]
-description = PyCQA security linter
-skip_install = true
-deps = bandit[toml]
-commands = bandit {posargs:-c pyproject.toml -r .}
-
 [testenv:black]
 description = Ensure consistent code style
 skip_install = true
@@ -43,20 +33,12 @@ commands = black {posargs:--check --diff pyclean tests}
 [testenv:clean]
 description = Clean up bytecode and build artifacts
 skip_install = true
-deps = pyclean
-commands = pyclean {posargs:. --debris --erase tests/junit-report.xml --yes}
-
-[testenv:flake8]
-description = Static code analysis and code style
-skip_install = true
-deps = flake8
-commands = flake8 {posargs}
-
-[testenv:isort]
-description = Ensure imports are ordered consistently
-skip_install = true
-deps = isort[colors]
-commands = isort {posargs:--check-only --diff pyclean tests}
+deps =
+    pyclean
+    ruff
+commands =
+    pyclean {posargs:. --debris --erase tests/junit-report.xml --yes}
+    ruff clean
 
 [testenv:license]
 description = Manage license compliance
@@ -78,24 +60,8 @@ passenv =
     TWINE_PASSWORD
     TWINE_REPOSITORY_URL
 
-[testenv:pylint]
-description = Check for errors and code smells
-deps = pylint
-commands = pylint {posargs:pyclean}
-
-[flake8]
-exclude = .tox,build,dist,pyclean.egg-info
-max-line-length = 88
-per-file-ignores =
-    pyclean/py2clean.py:E402
-    pyclean/py3clean.py:E402
-
-[pytest]
-addopts =
-    --color=yes
-    --doctest-modules
-    --ignore=pyclean/py2clean.py
-    --ignore=pyclean/py3clean.py
-    --ignore=pyclean/pypyclean.py
-    --junitxml=tests/junit-report.xml
-    --verbose
+[testenv:ruff]
+description = Lightening-fast linting for Python
+skip_install = true
+deps = ruff
+commands = ruff {posargs:. --show-source}


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/docs/) is the latest and greatest new kid on the block for lightening-fast linting and security checking of Python code. It's a drop-in replacement for a vast number of popular linters, among which:

- flake8
- isort
- pylint
- bandit