### PR TITLE
Handle exceptions centrally in main entry point

### DIFF
--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -106,9 +106,14 @@ def main(override=None):
     args = parse_arguments()
     if override or args.legacy:
         impl = compat.get_implementation(override=override)
-        impl.main(args)
+        pyclean_main = impl.main
     else:
-        modern.pyclean(args)
+        pyclean_main = modern.pyclean
+
+    try:
+        pyclean_main(args)
+    except Exception as err:
+        raise SystemExit(err)
 
 
 def py2clean():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ extend-select = ["B", "BLE", "C4", "C90", "COM", "DJ", "DTZ", "EM", "G", "I", "N
 extend-ignore = []
 
 [tool.ruff.per-file-ignores]
+"pyclean/cli.py" = ["B904", "BLE001"]
 "pyclean/compat.py" = ["C408"]
 "pyclean/modern.py" = ["B028", "B904"]
 "pyclean/py2clean.py" = ["E402", "PTH"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 Tests for the pyclean CLI
 """
 import os
+import platform
 import sys
 from importlib import import_module
 
@@ -97,6 +98,19 @@ def test_entrypoint_pypy_working(mock_import_module):
 
     args, _ = mock_import_module.call_args
     assert args == ('pyclean.pypyclean',)
+
+
+@pytest.mark.skipif(platform.system() != 'Linux', reason="requires Debian Linux")
+def test_main_handles_exceptions():
+    """
+    The main CLI entry point handles exceptions gracefully.
+    """
+    impl = pyclean.compat.get_implementation()
+
+    with patch.object(impl, 'main', side_effect=Exception('Something went wrong.')), \
+            pytest.raises(SystemExit, match='Something went wrong.'), \
+            ArgvContext('pyclean', '--package=foo', '--legacy'):
+        pyclean.cli.main()
 
 
 @patch('pyclean.cli.modern.pyclean')

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -9,8 +9,7 @@ from cli_test_helpers import ArgvContext
 import pyclean.cli
 
 
-@pytest.mark.skipif(platform.system() != 'Linux',
-                    reason="requires Debian Linux")
+@pytest.mark.skipif(platform.system() != 'Linux', reason="requires Debian Linux")
 def test_clean_directory():
     """
     Does traversing directories for cleaning work on Debian Linux?


### PR DESCRIPTION
The CLI should never abort with an ugly stack trace. We ensure this in `cli.main`.