### PR TITLE
Also ignore the `venv` folder by default

### DIFF
--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -17,7 +17,15 @@ def parse_arguments():
     debris_default_topics = ['cache', 'coverage', 'package', 'pytest']
     debris_optional_topics = ['jupyter', 'mypy', 'tox']
     debris_choices = ['all'] + debris_default_topics + debris_optional_topics
-    ignore_default_items = ['.git', '.hg', '.svn', '.tox', '.venv', 'node_modules']
+    ignore_default_items = [
+        '.git',
+        '.hg',
+        '.svn',
+        '.tox',
+        '.venv',
+        'node_modules',
+        'venv',
+    ]
 
     parser = argparse.ArgumentParser(
         description='Remove byte-compiled files for a package or project.',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,7 +160,7 @@ def test_ignore_option():
     """
     Does an --ignore option exist and append values to a list of defaults?
     """
-    default = ['.git', '.hg', '.svn', '.tox', '.venv', 'node_modules']
+    default = ['.git', '.hg', '.svn', '.tox', '.venv', 'node_modules', 'venv']
     expected_ignore_list = default + ['foo', 'bar']
 
     with ArgvContext('pyclean', '.', '--ignore', 'foo', 'bar'):


### PR DESCRIPTION
A folder called `venv` is favored by Tox (e.g. created by the `tox devenv` command), which is an indicator for widespread use. Hence, it seems like a good idea to include it into the list of folders ignored by default.

Note that you can always override this behavior by specifying folders you want PyClean to walk through, explicitly, as positional arguments (e.g. `pyclean venv`).