### PR TITLE
Upgrade Codacy reporter for GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Run tests
       run: tox run -e py
     - name: Upload coverage report
-      uses: codacy/codacy-coverage-reporter-action@v1
+      uses: codacy/codacy-coverage-reporter-action@v1.3.0
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: coverage.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,9 +52,6 @@ If you want to test against the various Python versions locally before
 pushing take a look at [pyenv][pyenv] or [rye][rye], which both allow you
 to install different Python versions on your computer in parallel.
 
-[pyenv]: https://github.com/pyenv/pyenv#installation
-[rye]: https://github.com/mitsuhiko/rye
-
 Developing locally
 ------------------
 
@@ -91,3 +88,6 @@ Or, for a specific branch:
 ```console
 python3 -m pip install git+https://github.com/bittner/pyclean@feature-branch#egg=pyclean
 ```
+
+[pyenv]: https://github.com/pyenv/pyenv#installation
+[rye]: https://github.com/mitsuhiko/rye


### PR DESCRIPTION
Try to fix Codacy configuration issue (e.g. [in PR #71](https://github.com/bittner/pyclean/actions/runs/6209035761/job/16944364074?pr=71)).

> ...
> d61e58a04f56811bf54f3ae2d4bfaabc453b3b80ec19d9d42b243968d9302aa2857b2233e5a9aa75f48a2b9455bae6f1fadbbb07f1471aa86ce385cb1b29ddcf  codacy-coverage-reporter-linux
> codacy-coverage-reporter-linux: OK
> 2023-09-19 22:47:28.161Z error [CodacyCoverageReporter] Invalid configuration: Either a project or account API token must be provided or available in an environment variable  - (CodacyCoverageReporter.scala:25)
> 
>  --> Failed!
```