### PR TITLE
Release v2.7.5

### DIFF
--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -52,7 +52,11 @@ def parse_arguments():
                         nargs='*', default=argparse.SUPPRESS, choices=debris_choices,
                         help='remove leftovers from popular Python development '
                              'tools (may be specified multiple times; '
-                             'default: %s)' % ' '.join(debris_default_topics))
+                             'optional: all %s; default: %s)' % (
+                                ' '.join(debris_optional_topics),
+                                ' '.join(debris_default_topics),
+                             ),
+                       )
     parser.add_argument('-e', '--erase', metavar='PATTERN', action='extend',
                         nargs='+', default=[],
                         help='delete files or folders matching a globbing '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyclean"
-version = "2.7.4"
+version = "2.7.5"
 description = "Pure Python cross-platform pyclean. Clean up your Python bytecode."
 readme = "README.rst"
 license = {file = "LICENSE"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ Tests for the pyclean CLI
 """
 import os
 import platform
+import re
 import sys
 from importlib import import_module
 
@@ -177,6 +178,22 @@ def test_debris_default_args():
         args = pyclean.cli.parse_arguments()
 
     assert args.debris == ['cache', 'coverage', 'package', 'pytest']
+
+
+def test_debris_optional_args():
+    """
+    Does the help screen explain all --debris options?
+    """
+    expected_debris_options_help = (
+        '(may be specified multiple times; '
+        'optional: all jupyter mypy ruff tox; '
+        'default: cache coverage package pytest)'
+    )
+
+    result = shell('pyclean --help')
+    normalized_stdout = re.sub(f'{os.linesep} *', ' ', result.stdout)
+
+    assert expected_debris_options_help in normalized_stdout
 
 
 def test_debris_all():


### PR DESCRIPTION
Includes:

* 3173673 Display non-default debris values in help screen
* 5b25a89 Remove ruff debris when specified (contributed by @miketheman)
* 32229e8 Fix Codacy complaint about MarkDown links
* 03f8953 Upgrade Codacy reporter for GHA
* d7bbe29 Also ignore the `venv` folder by default
