### PR TITLE
Fix wrongly displayed package version, add ruff to defaults

### DIFF
--- a/pyclean/__init__.py
+++ b/pyclean/__init__.py
@@ -1,3 +1,5 @@
 """
 Pure Python cross-platform pyclean. Clean up your Python bytecode.
 """
+
+__version__ = '2.7.6'

--- a/pyclean/__init__.py
+++ b/pyclean/__init__.py
@@ -1,5 +1,3 @@
 """
 Pure Python cross-platform pyclean. Clean up your Python bytecode.
 """
-
-__version__ = '2.7.3'

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -5,17 +5,22 @@ import argparse
 import logging
 import sys
 
-from . import __version__, compat, modern
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata
+
+from . import compat, modern
 
 log = logging.getLogger(__name__)
-
 
 def parse_arguments():
     """
     Parse and handle CLI arguments
     """
-    debris_default_topics = ['cache', 'coverage', 'package', 'pytest']
-    debris_optional_topics = ['jupyter', 'mypy', 'ruff', 'tox']
+    package_version = metadata.version('pyclean')
+    debris_default_topics = ['cache', 'coverage', 'package', 'pytest', 'ruff']
+    debris_optional_topics = ['jupyter', 'mypy', 'tox']
     debris_choices = ['all'] + debris_default_topics + debris_optional_topics
     ignore_default_items = [
         '.git',
@@ -34,7 +39,7 @@ def parse_arguments():
     if sys.version_info < (3, 8):
         parser.register('action', 'extend', compat.ExtendAction)
 
-    parser.add_argument('--version', action='version', version=__version__)
+    parser.add_argument('--version', action='version', version=package_version)
     parser.add_argument('-V', metavar='VERSION', dest='version',
                         help='specify Python version to clean')
     parser.add_argument('-p', '--package', metavar='PACKAGE',

--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -5,12 +5,7 @@ import argparse
 import logging
 import sys
 
-try:
-    from importlib import metadata
-except ImportError:
-    import importlib_metadata as metadata
-
-from . import compat, modern
+from . import __version__, compat, modern
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +13,6 @@ def parse_arguments():
     """
     Parse and handle CLI arguments
     """
-    package_version = metadata.version('pyclean')
     debris_default_topics = ['cache', 'coverage', 'package', 'pytest', 'ruff']
     debris_optional_topics = ['jupyter', 'mypy', 'tox']
     debris_choices = ['all'] + debris_default_topics + debris_optional_topics
@@ -39,7 +33,7 @@ def parse_arguments():
     if sys.version_info < (3, 8):
         parser.register('action', 'extend', compat.ExtendAction)
 
-    parser.add_argument('--version', action='version', version=package_version)
+    parser.add_argument('--version', action='version', version=__version__)
     parser.add_argument('-V', metavar='VERSION', dest='version',
                         help='specify Python version to clean')
     parser.add_argument('-p', '--package', metavar='PACKAGE',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyclean"
-version = "2.7.5"
+version = "2.7.6"
 description = "Pure Python cross-platform pyclean. Clean up your Python bytecode."
 readme = "README.rst"
 license = {file = "LICENSE"}
@@ -38,6 +38,9 @@ keywords = [
   "bytecode",
   "cli",
   "tools",
+]
+dependencies = [
+  "importlib-metadata; python_version < '3.8'",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,6 @@ keywords = [
   "cli",
   "tools",
 ]
-dependencies = [
-  "importlib-metadata; python_version < '3.8'",
-]
 
 [project.scripts]
 pyclean = "pyclean.cli:main"
@@ -80,3 +77,6 @@ extend-ignore = []
 
 [tool.setuptools]
 packages = ["pyclean"]
+
+[tool.setuptools.dynamic]
+version = {attr = "pyclean.__version__"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,11 @@ import sys
 from importlib import import_module
 
 try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata
+
+try:
     from unittest.mock import patch
 except ImportError:  # Python 2.7, PyPy2
     from mock import patch
@@ -177,7 +182,7 @@ def test_debris_default_args():
     with ArgvContext('pyclean', 'foo', '--debris'):
         args = pyclean.cli.parse_arguments()
 
-    assert args.debris == ['cache', 'coverage', 'package', 'pytest']
+    assert args.debris == ['cache', 'coverage', 'package', 'pytest', 'ruff']
 
 
 def test_debris_optional_args():
@@ -186,8 +191,8 @@ def test_debris_optional_args():
     """
     expected_debris_options_help = (
         '(may be specified multiple times; '
-        'optional: all jupyter mypy ruff tox; '
-        'default: cache coverage package pytest)'
+        'optional: all jupyter mypy tox; '
+        'default: cache coverage package pytest ruff)'
     )
 
     result = shell('pyclean --help')
@@ -208,9 +213,9 @@ def test_debris_all():
         'coverage',
         'package',
         'pytest',
+        'ruff',
         'jupyter',
         'mypy',
-        'ruff',
         'tox',
     ]
 
@@ -286,7 +291,8 @@ def test_version_option():
     """
     Does --version yield the expected information?
     """
-    expected_output = '%s%s' % (pyclean.__version__, os.linesep)
+    pkg_version = metadata.version('pyclean')
+    expected_output = '%s%s' % (pkg_version, os.linesep)
 
     result = shell('pyclean --version')
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,11 +8,6 @@ import sys
 from importlib import import_module
 
 try:
-    from importlib import metadata
-except ImportError:
-    import importlib_metadata as metadata
-
-try:
     from unittest.mock import patch
 except ImportError:  # Python 2.7, PyPy2
     from mock import patch
@@ -20,6 +15,7 @@ except ImportError:  # Python 2.7, PyPy2
 import pytest
 from cli_test_helpers import ArgvContext, shell
 
+import pyclean
 import pyclean.cli
 
 
@@ -291,8 +287,7 @@ def test_version_option():
     """
     Does --version yield the expected information?
     """
-    pkg_version = metadata.version('pyclean')
-    expected_output = '%s%s' % (pkg_version, os.linesep)
+    expected_output = '%s%s' % (pyclean.__version__, os.linesep)
 
     result = shell('pyclean --version')
 

--- a/tests/test_modern.py
+++ b/tests/test_modern.py
@@ -257,7 +257,7 @@ def test_dryrun(
     ('options', 'scanned_topics'),
     [
         ([], []),
-        (['-d'], ['cache', 'coverage', 'package', 'pytest']),
+        (['-d'], ['cache', 'coverage', 'package', 'pytest', 'ruff']),
         (['-d', 'coverage', 'package'], ['coverage', 'package']),
         (['-d', 'jupyter', 'mypy', 'tox'], ['jupyter', 'mypy', 'tox']),
     ],


### PR DESCRIPTION
In version 2.7.5 `pyclean --version` displays `2.7.3`.