### PR TITLE
Simplify pipeline code, no unnecessary install of wheel package

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,6 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install build tools
-      run: |
-        python -m pip install tox wheel
+      run: pip install tox
     - name: Run ${{ matrix.env }}
       run: tox run -e ${{ matrix.env }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: '3.10'
     - name: Install build tools
-      run: python -m pip install tox wheel
+      run: pip install tox
     - name: Verify package version is same as Git tag
       run: tox run -qe ensure_version_matches -- $GIT_TAG
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install build tools
-      run: python -m pip install tox wheel
+      run: pip install tox
     - name: Run tests
       run: tox run -e py
     - name: Upload coverage report


### PR DESCRIPTION
The `python -m build` command [executed by Tox](https://github.com/bittner/pyclean/blob/main/tox.ini#L54-L66) takes care of installing the `wheel` package, which is needed for building a wheel distribution from the source distribution package.

Hence, it's unnecessary to have the `wheel` package installed by the pipeline, explicitly. Even worse, it creates visual noise, which we want to avoid.

`python -m pip install ...` is the explicit form of `pip install ...` when several versions of Python are installed, including their installed version of Pip. If we don't need that type of control we can simply use `pip install`, which again avoids visual noise that the spectator needs to interpret.