### PR TITLE
Use generic name for linting job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         env:
-        - ruff
+        - lint
+        - format
         - package
     steps:
     - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,8 @@ tox list
 ```
 
 ```console
-# run just flake8 and the tests for Python 3.10
-tox -e flake8,py310
+# run just linting and the tests for Python 3.12
+tox -e lint,py312
 ```
 
 ```console

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,14 +61,16 @@ addopts = "--color=yes --doctest-modules --ignore=pyclean/py2clean.py --ignore=p
 
 [tool.ruff]
 extend-exclude = ["py2clean.py", "py3clean.py", "pypyclean.py"]
-extend-select = ["ALL"]
-extend-ignore = ["ANN", "D", "FBT002", "INP001", "Q000", "TRY200", "UP"]
 
 [tool.ruff.format]
 quote-style = "single"
 exclude = ["py2clean.py", "py3clean.py", "pypyclean.py"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint]
+extend-select = ["ALL"]
+extend-ignore = ["ANN", "B904", "D", "FBT002", "INP001", "Q000", "UP"]
+
+[tool.ruff.lint.per-file-ignores]
 "pyclean/cli.py" = ["B904", "BLE001"]
 "pyclean/compat.py" = ["C408"]
 "pyclean/modern.py" = ["B028", "B904"]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 [tox]
 envlist =
-    ruff
+    lint
     format
     py2{7}
     pypy2{7}
@@ -40,7 +40,7 @@ setenv =
     GIT_TAG={posargs}
 
 [testenv:format]
-description = Ensure consistent code style
+description = Ensure consistent code style (Ruff)
 skip_install = true
 deps = ruff
 commands = ruff format {posargs:--check --diff .}
@@ -50,6 +50,12 @@ description = Manage license compliance
 skip_install = true
 deps = reuse
 commands = reuse {posargs:lint}
+
+[testenv:lint]
+description = Lightening-fast linting (Ruff)
+skip_install = true
+deps = ruff
+commands = ruff check {posargs:.}
 
 [testenv:package]
 description = Build package and check metadata (or upload package)
@@ -64,9 +70,3 @@ passenv =
     TWINE_USERNAME
     TWINE_PASSWORD
     TWINE_REPOSITORY_URL
-
-[testenv:ruff]
-description = Lightening-fast linting for Python
-skip_install = true
-deps = ruff
-commands = ruff check {posargs:--show-source .}


### PR DESCRIPTION
Developers are humans, too. They deserve being served by the [principle of least surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment). We hence want the linting job to be called "lint", not "ruff". Also, let's call it what it's called also elsewhere.