### PR TITLE
Continue to run tests against older Pythons

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install build tools
       run: pip install tox
     - name: Run ${{ matrix.env }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install build tools
       run: pip install tox
     - name: Verify package version is same as Git tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
@@ -37,12 +36,10 @@ jobs:
         - pypy-3.8
         - pypy-3.9
         - pypy-3.10
-        exclude:  # Python < v3.8 does not support Apple Silicon ARM64
-        - platform: macos-latest
-          python-version: '3.7'
-        include:  # So run those legacy versions on Intel CPUs
-        - platform: macos-13
-          python-version: '3.7'
+        include:  # Python < 3.8 does not support Apple Silicon ARM64, run those legacy versions on Intel CPUs
+        - {python-version: '3.7', platform: macos-13}
+        - {python-version: '3.7', platform: ubuntu-20.04}
+        - {python-version: '3.7', platform: windows-latest}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -51,7 +48,7 @@ jobs:
     - name: Install build tools
       run: pip install tox
     - name: Run tests
-      run: tox run -e py
+      run: tox -e py
     - name: Upload coverage report
       uses: codacy/codacy-coverage-reporter-action@v1.3.0
       with:


### PR DESCRIPTION
The GHA infrastructure continues to phase out older Python versions when they update their CI runner VMs.

We still want to run the entire test suite against all old Python versions we declare to support, hence we must tell GHA to use VM images with older macOS and Ubuntu systems, which still have those versions included.