### PR TITLE
feat: Add pyright as a debris topic

### DIFF
--- a/pyclean/cli.py
+++ b/pyclean/cli.py
@@ -19,7 +19,7 @@ def parse_arguments():
     Parse and handle CLI arguments.
     """
     debris_default_topics = ['cache', 'coverage', 'package', 'pytest', 'ruff']
-    debris_optional_topics = ['jupyter', 'mypy', 'tox']
+    debris_optional_topics = ['jupyter', 'mypy', 'pyright', 'tox']
     debris_choices = ['all', *debris_default_topics, *debris_optional_topics]
     ignore_default_items = [
         '.git',

--- a/pyclean/modern.py
+++ b/pyclean/modern.py
@@ -55,6 +55,13 @@ DEBRIS_TOPICS = {
         '.ruff_cache/**/*',
         '.ruff_cache/',
     ],
+    'pyright': [
+        '.pyright-app-cache-**/*',
+        '.pyright-app-cache-*/',
+        '.pyright-stubs-**/*',
+        '.pyright-stubs-*/',
+        '.pyright/',
+    ],
     'tox': [
         '.tox/**/*',
         '.tox/',


### PR DESCRIPTION
This PR adds support for cleaning `pyright` cache directories.

- Adds `pyright` to the optional debris topics.
- Adds patterns for `.pyright/`, `.pyright-app-cache-*`, and `.pyright-stubs-*`.